### PR TITLE
feature/31 implement start conditions for PosTable entry (step 2)

### DIFF
--- a/remove-this-file.txt
+++ b/remove-this-file.txt
@@ -1,0 +1,2 @@
+This file was only added to allow setting up the PR.
+Please delete before merging.

--- a/remove-this-file.txt
+++ b/remove-this-file.txt
@@ -1,2 +1,0 @@
-This file was only added to allow setting up the PR.
-Please delete before merging.

--- a/source/examples/functions/MceManualMotion/source.iecst
+++ b/source/examples/functions/MceManualMotion/source.iecst
@@ -390,7 +390,7 @@ FOR i := 0 TO 5 DO
   IF NOT io.bBusy AND NOT io.bCoasting THEN
     io.aJogRobotAxisNegIndicator[i] := FALSE;
     io.aJogRobotAxisPosIndicator[i] := FALSE;
-  END_IF
+  END_IF;
 END_FOR;
 
 

--- a/source/examples/functions/McePosTable/definition.yaml
+++ b/source/examples/functions/McePosTable/definition.yaml
@@ -1,6 +1,11 @@
 author: Rioual
 comment: Performed a trajectory stored in a PosTable
 changelog:
+  - version: 0.4.0
+    date: 2024-05-15
+    author: Rioual
+    changed:
+      - Start conditions without standstill
   - version: 0.3.0
     date: 2024-03-28
     author: Rioual

--- a/source/examples/functions/McePosTable/definition.yaml
+++ b/source/examples/functions/McePosTable/definition.yaml
@@ -149,18 +149,6 @@ var:
         type: BOOL
         comment: stop PosTable after the last entry
       - name: stConditionResult
-      - name: aConditionsCopy
-        type: ARRAY [0..GVL.CONDITIONS_UBOUND] OF BOOL
-        comment: filtered conditions status
-      - name: aOsrConditions
-        type: ARRAY [0..GVL.CONDITIONS_UBOUND] OF BOOL
-        comment: rising edge
-      - name: aOsfConditions
-        type: ARRAY [0..GVL.CONDITIONS_UBOUND] OF BOOL
-        comment: falling edge
-      - name: aOneShotCondition
-        type: ARRAY [0..GVL.CONDITIONS_UBOUND] OF BOOL
-        comment: rising edge signals
   - kind: temp
     var:
       - name: i
@@ -179,6 +167,9 @@ var:
       - name: nNextIndex
         type: INT
         comment: next valid index of PosTable
+      - name: nNextValidLoadIndex
+        type: INT
+        comment: next valid loadIndex of PosTable
   - kind: constant
     var:
       - name: QA_MAX

--- a/source/examples/functions/McePosTable/definition.yaml
+++ b/source/examples/functions/McePosTable/definition.yaml
@@ -144,6 +144,18 @@ var:
         type: BOOL
         comment: stop PosTable after the last entry
       - name: stConditionResult
+      - name: aConditionsCopy
+        type: ARRAY [0..GVL.CONDITIONS_UBOUND] OF BOOL
+        comment: filtered conditions status
+      - name: aOsrConditions
+        type: ARRAY [0..GVL.CONDITIONS_UBOUND] OF BOOL
+        comment: rising edge
+      - name: aOsfConditions
+        type: ARRAY [0..GVL.CONDITIONS_UBOUND] OF BOOL
+        comment: falling edge
+      - name: aOneShotCondition
+        type: ARRAY [0..GVL.CONDITIONS_UBOUND] OF BOOL
+        comment: rising edge signals
   - kind: temp
     var:
       - name: i
@@ -156,6 +168,12 @@ var:
       - name: bToolDone
         type: BOOL
         comment: tool has been loaded by MLxRobotSelectTool
+      - name: bUpdateQA
+        type: BOOL
+        comment: QA update condition
+      - name: nNextIndex
+        type: INT
+        comment: next valid index of PosTable
   - kind: constant
     var:
       - name: QA_MAX

--- a/source/examples/functions/McePosTable/index.md
+++ b/source/examples/functions/McePosTable/index.md
@@ -176,7 +176,7 @@ IF GVL.stPosTable[0].bActionStart THEN
   END_CASE;
 ELSE
   GVL.stPosTable[0].bCustomActionDone := FALSE;
-END_IF
+END_IF;
 ```
 
 ### McePosTable controlled by a higher-level state machine

--- a/source/examples/functions/McePosTable/source.iecst
+++ b/source/examples/functions/McePosTable/source.iecst
@@ -59,8 +59,10 @@ bAllowQueuing := (io.nMode = PT_MODE_0) AND io.bRun;
 
 MEMUtils.MemSet(pbyBuffer := ADR(stConditionResult), byValue :=  0, dwSize :=  SIZEOF(stConditionResult));
 
-// clear Enable signals
-MEMUtils.MemSet(pbyBuffer := ADR(aEnable), byValue :=  0, dwSize :=  SIZEOF(aEnable));
+// clear Enable signals but keep signals enabled if an error occurs
+IF io.nSmPosTable <> 99 THEN
+  MEMUtils.MemSet(pbyBuffer := ADR(aEnable), byValue :=  0, dwSize :=  SIZEOF(aEnable));
+END_IF
 io.bError := FALSE;
 
 // Update QA
@@ -321,6 +323,8 @@ CASE io.nSmPosTable OF
     io.bError := TRUE;
 
     IF NOT io.bRun THEN
+      // Reset FB
+      MEMUtils.MemSet(pbyBuffer := ADR(aEnable), byValue :=  0, dwSize :=  SIZEOF(aEnable));
       io.nSmPosTable := 60;
     END_IF;
 END_CASE;

--- a/source/examples/functions/McePosTable/source.iecst
+++ b/source/examples/functions/McePosTable/source.iecst
@@ -29,7 +29,7 @@ END_IF;
 bStopAfterLastEntry := ((io.nCycleNr + 1) >= io.nNrOfCycles) AND NOT (io.nNrOfCycles = 0);
 
 bUpdateQA := FALSE;
-IF nQA < QA_MAX THEN
+IF (io.nMode = PT_MODE_0) AND (nQA < QA_MAX) THEN
   nNextValidLoadIndex := McePosTableFindEntry(io.nLoadIndex, 1, nPosTableSize, NOT bStopAfterLastEntry, posTable);
   IF nNextValidLoadIndex >= 0 THEN
     stConditionResult := McePosTableCheckConditions(

--- a/source/examples/functions/McePosTable/source.iecst
+++ b/source/examples/functions/McePosTable/source.iecst
@@ -114,6 +114,7 @@ CASE io.nSmPosTable OF
                                 waitBeforeNextEntry := bWaitBeforeNextEntry,
                                 posTable := posTable);
         IF io.nIndex < 0 THEN
+          io.nIndex := 0;
           io.nSmPosTable := 50;
         ELSE
           stConditionResult := McePosTableCheckConditions(

--- a/source/examples/functions/McePosTable/source.iecst
+++ b/source/examples/functions/McePosTable/source.iecst
@@ -29,29 +29,17 @@ END_IF;
 bStopAfterLastEntry := ((io.nCycleNr + 1) >= io.nNrOfCycles) AND NOT (io.nNrOfCycles = 0);
 
 bUpdateQA := FALSE;
-FOR i := 0 TO GVL.CONDITIONS_UBOUND DO
-  aOsrConditions[i] := io.aConditions[i] AND NOT aOneShotCondition[i];
-  aOsfConditions[i] := NOT io.aConditions[i] AND aOneShotCondition[i];
-  aOneShotCondition[i] := io.aConditions[i];
-  
-  IF aOsrConditions[i] THEN
-    aConditionsCopy[i] := TRUE;
-    bUpdateQA := TRUE;
+IF nQA < QA_MAX THEN
+  nNextValidLoadIndex := McePosTableFindEntry(io.nLoadIndex, 1, nPosTableSize, NOT bStopAfterLastEntry, posTable);
+  IF nNextValidLoadIndex >= 0 THEN
+    stConditionResult := McePosTableCheckConditions(
+      index := nNextValidLoadIndex,
+      posTableSize := nPosTableSize,
+      conditions := io.aConditions,
+      posTable := posTable);
+    bUpdateQA := stConditionResult.bConditionsOk;
   END_IF
-  
-  IF aOsfConditions[i] THEN
-    aConditionsCopy[i] := FALSE;
-    IF (io.nLoadIndex <> io.nIndex) AND (10 <= io.nSmPosTable AND io.nSmPosTable < 30) THEN
-      nNextIndex := io.nIndex;
-      REPEAT
-        aConditionsCopy[i] := aConditionsCopy[i] OR posTable.stEntry[nNextIndex].aStartCondition[i];
-        nNextIndex := McePosTableFindEntry(nNextIndex, 1, nPosTableSize, NOT bStopAfterLastEntry, posTable);
-      UNTIL nNextIndex = io.nLoadIndex OR nNextIndex < 0
-      END_REPEAT
-      aConditionsCopy[i] := aConditionsCopy[i] OR posTable.stEntry[nNextIndex].aStartCondition[i];
-    END_IF
-  END_IF
-END_FOR
+END_IF
 
 bWaiting := FALSE;
 
@@ -72,7 +60,8 @@ IF bUpdateQA THEN
   McePosTableRecalcQA(allowQueuing := bAllowQueuing,
                     firstMove := bFirstMove,
                     stopAfterLastEntry := bStopAfterLastEntry,
-                    conditions := aConditionsCopy,
+                    loadIndex := io.nLoadIndex,
+                    conditions := io.aConditions,
                     posTable := posTable,
                     QA := nQA,
                     lastEntry := bLastEntry,
@@ -112,11 +101,11 @@ CASE io.nSmPosTable OF
       bFirstMove := TRUE;
 
       IF ((io.nMode <> PT_MODE_2 AND io.bRun) OR (io.nMode = PT_MODE_2 AND bOsrStep AND io.bRun)) THEN
-        aConditionsCopy := io.aConditions;
         McePosTableUpdateIndex( allowQueuing := bAllowQueuing,
                                 firstMove := bFirstMove,
                                 stopAfterLastEntry := bStopAfterLastEntry,
-                                conditions := aConditionsCopy,
+                                loadIndex := io.nLoadIndex,
+                                conditions := io.aConditions,
                                 index := io.nIndex,
                                 QA := nQA,
                                 lastEntry := bLastEntry,
@@ -129,7 +118,7 @@ CASE io.nSmPosTable OF
           stConditionResult := McePosTableCheckConditions(
             index := io.nIndex,
             posTableSize := nPosTableSize,
-            conditions := aConditionsCopy,
+            conditions := io.aConditions,
             posTable := posTable);
 
           IF NOT stConditionResult.bConditionsOk THEN
@@ -151,7 +140,7 @@ CASE io.nSmPosTable OF
       stConditionResult := McePosTableCheckConditions(
         index := io.nIndex,
         posTableSize := nPosTableSize,
-        conditions := aConditionsCopy,
+        conditions := io.aConditions,
         posTable := posTable);
 
       IF stConditionResult.bConditionsOk AND ((io.nMode <> PT_MODE_2 AND io.bRun) OR (bOsrStep OR (nQA > 0))) THEN
@@ -159,7 +148,8 @@ CASE io.nSmPosTable OF
         McePosTableRecalcQA(allowQueuing := bAllowQueuing,
           firstMove := bFirstMove,
           stopAfterLastEntry := bStopAfterLastEntry,
-          conditions := aConditionsCopy,
+          loadIndex := io.nLoadIndex,
+          conditions := io.aConditions,
           posTable := posTable,
           QA := nQA,
           lastEntry := bLastEntry,
@@ -213,7 +203,8 @@ CASE io.nSmPosTable OF
             McePosTableUpdateIndex( allowQueuing := bAllowQueuing,
                                     firstMove := bFirstMove,
                                     stopAfterLastEntry := bStopAfterLastEntry,
-                                    conditions := aConditionsCopy,
+                                    loadIndex := io.nLoadIndex,
+                                    conditions := io.aConditions,
                                     index := io.nIndex,
                                     QA := nQA,
                                     lastEntry := bLastEntry,
@@ -259,7 +250,8 @@ CASE io.nSmPosTable OF
           McePosTableUpdateIndex( allowQueuing := bAllowQueuing,
                                   firstMove := bFirstMove,
                                   stopAfterLastEntry := bStopAfterLastEntry,
-                                  conditions := aConditionsCopy,
+                                  loadIndex := io.nLoadIndex,
+                                  conditions := io.aConditions,
                                   index := io.nIndex,
                                   QA := nQA,
                                   lastEntry := bLastEntry,
@@ -287,7 +279,8 @@ CASE io.nSmPosTable OF
       McePosTableUpdateIndex( allowQueuing := bAllowQueuing,
                               firstMove := bFirstMove,
                               stopAfterLastEntry := FALSE,
-                              conditions := aConditionsCopy,
+                              loadIndex := io.nLoadIndex,
+                              conditions := io.aConditions,
                               index := io.nIndex,
                               QA := nQA,
                               lastEntry := bLastEntry,
@@ -381,7 +374,7 @@ FOR i := 0 TO QA_MAX DO
     McePosTableUpdateLoadIndex( allowQueuing := bAllowQueuing,
                                 firstMove := bFirstMove,
                                 stopAfterLastEntry := ((io.nCycleNr + 1) >= io.nNrOfCycles) AND NOT (io.nNrOfCycles = 0),
-                                conditions := aConditionsCopy,
+                                conditions := io.aConditions,
                                 index := io.nIndex,
                                 loadIndex := io.nLoadIndex,
                                 QA := nQA,

--- a/source/examples/functions/McePosTable/source.iecst
+++ b/source/examples/functions/McePosTable/source.iecst
@@ -106,7 +106,7 @@ CASE io.nSmPosTable OF
       io.nSmPosTable := 60;
     ELSIF io.bSystemReady THEN
 
-      bWaiting := (io.nMode = PT_MODE_2);
+      bWaiting := (io.nMode = PT_MODE_2) AND io.bRun;
       bFirstMove := TRUE;
 
       IF ((io.nMode <> PT_MODE_2 AND io.bRun) OR (io.nMode = PT_MODE_2 AND bOsrStep AND io.bRun)) THEN

--- a/source/examples/functions/McePosTable/source.iecst
+++ b/source/examples/functions/McePosTable/source.iecst
@@ -38,8 +38,8 @@ IF nQA < QA_MAX THEN
       conditions := io.aConditions,
       posTable := posTable);
     bUpdateQA := stConditionResult.bConditionsOk;
-  END_IF
-END_IF
+  END_IF;
+END_IF;
 
 bWaiting := FALSE;
 
@@ -50,7 +50,7 @@ MEMUtils.MemSet(pbyBuffer := ADR(stConditionResult), byValue :=  0, dwSize :=  S
 // clear Enable signals but keep signals enabled if an error occurs
 IF io.nSmPosTable <> 99 THEN
   MEMUtils.MemSet(pbyBuffer := ADR(aEnable), byValue :=  0, dwSize :=  SIZEOF(aEnable));
-END_IF
+END_IF;
 io.bError := FALSE;
 
 // Update QA
@@ -127,7 +127,7 @@ CASE io.nSmPosTable OF
             io.nSmPosTable := 5;
           ELSE
             io.nSmPosTable := 10;
-          END_IF
+          END_IF;
         END_IF;
       END_IF;
     END_IF;
@@ -160,8 +160,8 @@ CASE io.nSmPosTable OF
           index := io.nIndex
           );
         io.nSmPosTable := 10;
-      END_IF
-    END_IF
+      END_IF;
+    END_IF;
 
   // -------------------------------------
   // state 10..29 - handle motion commands
@@ -201,7 +201,7 @@ CASE io.nSmPosTable OF
               io.nSmPosTable := 5;
             ELSE
               io.nSmPosTable := nInstanceNumber[1] + 10;
-            END_IF
+            END_IF;
             McePosTableUpdateIndex( allowQueuing := bAllowQueuing,
                                     firstMove := bFirstMove,
                                     stopAfterLastEntry := bStopAfterLastEntry,
@@ -248,7 +248,7 @@ CASE io.nSmPosTable OF
             io.nSmPosTable := 5;
           ELSE
             io.nSmPosTable := 10;
-          END_IF
+          END_IF;
           McePosTableUpdateIndex( allowQueuing := bAllowQueuing,
                                   firstMove := bFirstMove,
                                   stopAfterLastEntry := bStopAfterLastEntry,
@@ -277,7 +277,7 @@ CASE io.nSmPosTable OF
         io.nSmPosTable := 5;
       ELSE
         io.nSmPosTable := 10;
-      END_IF
+      END_IF;
       McePosTableUpdateIndex( allowQueuing := bAllowQueuing,
                               firstMove := bFirstMove,
                               stopAfterLastEntry := FALSE,

--- a/source/examples/functions/McePosTable/source.iecst
+++ b/source/examples/functions/McePosTable/source.iecst
@@ -30,27 +30,27 @@ bStopAfterLastEntry := ((io.nCycleNr + 1) >= io.nNrOfCycles) AND NOT (io.nNrOfCy
 
 bUpdateQA := FALSE;
 FOR i := 0 TO GVL.CONDITIONS_UBOUND DO
-	aOsrConditions[i] := io.aConditions[i] AND NOT aOneShotCondition[i];
-	aOsfConditions[i] := NOT io.aConditions[i] AND aOneShotCondition[i];
-	aOneShotCondition[i] := io.aConditions[i];
-	
-	IF aOsrConditions[i] THEN
-		aConditionsCopy[i] := TRUE;
-		bUpdateQA := TRUE;
-	END_IF
-	
-	IF aOsfConditions[i] THEN
-		aConditionsCopy[i] := FALSE;
-		IF (io.nLoadIndex <> io.nIndex) AND (10 <= io.nSmPosTable AND io.nSmPosTable < 30) THEN
-			nNextIndex := io.nIndex;
+  aOsrConditions[i] := io.aConditions[i] AND NOT aOneShotCondition[i];
+  aOsfConditions[i] := NOT io.aConditions[i] AND aOneShotCondition[i];
+  aOneShotCondition[i] := io.aConditions[i];
+  
+  IF aOsrConditions[i] THEN
+    aConditionsCopy[i] := TRUE;
+    bUpdateQA := TRUE;
+  END_IF
+  
+  IF aOsfConditions[i] THEN
+    aConditionsCopy[i] := FALSE;
+    IF (io.nLoadIndex <> io.nIndex) AND (10 <= io.nSmPosTable AND io.nSmPosTable < 30) THEN
+      nNextIndex := io.nIndex;
       REPEAT
-				aConditionsCopy[i] := aConditionsCopy[i] OR posTable.stEntry[nNextIndex].aStartCondition[i];
-				nNextIndex := McePosTableFindEntry(nNextIndex, 1, nPosTableSize, NOT bStopAfterLastEntry, posTable);
-			UNTIL nNextIndex = io.nLoadIndex OR nNextIndex < 0
-			END_REPEAT
+        aConditionsCopy[i] := aConditionsCopy[i] OR posTable.stEntry[nNextIndex].aStartCondition[i];
+        nNextIndex := McePosTableFindEntry(nNextIndex, 1, nPosTableSize, NOT bStopAfterLastEntry, posTable);
+      UNTIL nNextIndex = io.nLoadIndex OR nNextIndex < 0
+      END_REPEAT
       aConditionsCopy[i] := aConditionsCopy[i] OR posTable.stEntry[nNextIndex].aStartCondition[i];
-		END_IF
-	END_IF
+    END_IF
+  END_IF
 END_FOR
 
 bWaiting := FALSE;
@@ -72,7 +72,7 @@ IF bUpdateQA THEN
   McePosTableRecalcQA(allowQueuing := bAllowQueuing,
                     firstMove := bFirstMove,
                     stopAfterLastEntry := bStopAfterLastEntry,
-										conditions := aConditionsCopy,
+                    conditions := aConditionsCopy,
                     posTable := posTable,
                     QA := nQA,
                     lastEntry := bLastEntry,
@@ -112,11 +112,11 @@ CASE io.nSmPosTable OF
       bFirstMove := TRUE;
 
       IF ((io.nMode <> PT_MODE_2 AND io.bRun) OR (io.nMode = PT_MODE_2 AND bOsrStep AND io.bRun)) THEN
-				aConditionsCopy := io.aConditions;
+        aConditionsCopy := io.aConditions;
         McePosTableUpdateIndex( allowQueuing := bAllowQueuing,
                                 firstMove := bFirstMove,
                                 stopAfterLastEntry := bStopAfterLastEntry,
-																conditions := aConditionsCopy,
+                                conditions := aConditionsCopy,
                                 index := io.nIndex,
                                 QA := nQA,
                                 lastEntry := bLastEntry,
@@ -213,7 +213,7 @@ CASE io.nSmPosTable OF
             McePosTableUpdateIndex( allowQueuing := bAllowQueuing,
                                     firstMove := bFirstMove,
                                     stopAfterLastEntry := bStopAfterLastEntry,
-																		conditions := aConditionsCopy,
+                                    conditions := aConditionsCopy,
                                     index := io.nIndex,
                                     QA := nQA,
                                     lastEntry := bLastEntry,
@@ -259,7 +259,7 @@ CASE io.nSmPosTable OF
           McePosTableUpdateIndex( allowQueuing := bAllowQueuing,
                                   firstMove := bFirstMove,
                                   stopAfterLastEntry := bStopAfterLastEntry,
-																	conditions := aConditionsCopy,
+                                  conditions := aConditionsCopy,
                                   index := io.nIndex,
                                   QA := nQA,
                                   lastEntry := bLastEntry,
@@ -287,7 +287,7 @@ CASE io.nSmPosTable OF
       McePosTableUpdateIndex( allowQueuing := bAllowQueuing,
                               firstMove := bFirstMove,
                               stopAfterLastEntry := FALSE,
-															conditions := aConditionsCopy,
+                              conditions := aConditionsCopy,
                               index := io.nIndex,
                               QA := nQA,
                               lastEntry := bLastEntry,
@@ -381,7 +381,7 @@ FOR i := 0 TO QA_MAX DO
     McePosTableUpdateLoadIndex( allowQueuing := bAllowQueuing,
                                 firstMove := bFirstMove,
                                 stopAfterLastEntry := ((io.nCycleNr + 1) >= io.nNrOfCycles) AND NOT (io.nNrOfCycles = 0),
-																conditions := aConditionsCopy,
+                                conditions := aConditionsCopy,
                                 index := io.nIndex,
                                 loadIndex := io.nLoadIndex,
                                 QA := nQA,

--- a/source/examples/functions/McePosTable/source.iecst
+++ b/source/examples/functions/McePosTable/source.iecst
@@ -1,6 +1,9 @@
 // -----------------------------------------------------------------------------
 // common
 // -----------------------------------------------------------------------------
+io.nIndex := LIMIT(0, io.nIndex, nPosTableSize - 1);
+io.nLoadIndex := LIMIT(0, io.nLoadIndex, nPosTableSize - 1);
+
 bOsrStep := io.bStep AND NOT aOneShots[0];
 aOneShots[0] := io.bStep;
 bOsrSystemReady := io.bSystemReady AND NOT aOneShots[1];
@@ -23,14 +26,36 @@ IF bOsfLastMoveInProcess AND io.bBusy THEN
   io.nCycleNr := io.nCycleNr + 1;
 END_IF;
 
-io.nIndex := LIMIT(0, io.nIndex, nPosTableSize - 1);
-io.nLoadIndex := LIMIT(0, io.nLoadIndex, nPosTableSize - 1);
+bStopAfterLastEntry := ((io.nCycleNr + 1) >= io.nNrOfCycles) AND NOT (io.nNrOfCycles = 0);
+
+bUpdateQA := FALSE;
+FOR i := 0 TO GVL.CONDITIONS_UBOUND DO
+	aOsrConditions[i] := io.aConditions[i] AND NOT aOneShotCondition[i];
+	aOsfConditions[i] := NOT io.aConditions[i] AND aOneShotCondition[i];
+	aOneShotCondition[i] := io.aConditions[i];
+	
+	IF aOsrConditions[i] THEN
+		aConditionsCopy[i] := TRUE;
+		bUpdateQA := TRUE;
+	END_IF
+	
+	IF aOsfConditions[i] THEN
+		aConditionsCopy[i] := FALSE;
+		IF (io.nLoadIndex <> io.nIndex) THEN
+			nNextIndex := io.nIndex;
+      REPEAT
+				aConditionsCopy[i] := aConditionsCopy[i] OR posTable.stEntry[nNextIndex].aStartCondition[i];
+				nNextIndex := McePosTableFindEntry(nNextIndex, 1, nPosTableSize, NOT bStopAfterLastEntry, posTable);
+			UNTIL nNextIndex = io.nLoadIndex OR nNextIndex < 0
+			END_REPEAT
+      aConditionsCopy[i] := aConditionsCopy[i] OR posTable.stEntry[nNextIndex].aStartCondition[i];
+		END_IF
+	END_IF
+END_FOR
 
 bWaiting := FALSE;
 
 bAllowQueuing := (io.nMode = PT_MODE_0) AND io.bRun;
-
-bStopAfterLastEntry := ((io.nCycleNr + 1) >= io.nNrOfCycles) AND NOT (io.nNrOfCycles = 0);
 
 MEMUtils.MemSet(pbyBuffer := ADR(stConditionResult), byValue :=  0, dwSize :=  SIZEOF(stConditionResult));
 
@@ -39,11 +64,13 @@ MEMUtils.MemSet(pbyBuffer := ADR(aEnable), byValue :=  0, dwSize :=  SIZEOF(aEna
 io.bError := FALSE;
 
 // Update QA
-IF bOsrRecalcQA OR bOsrSystemReady THEN
-  bFirstMove := bOsrSystemReady OR bOsrRun; // only if first move after standstill
+bUpdateQA := bUpdateQA OR bOsrRecalcQA OR bOsrSystemReady;
+IF bUpdateQA THEN
+  bFirstMove := bFirstMove OR bOsrSystemReady OR bOsrRun; // only if first move after standstill
   McePosTableRecalcQA(allowQueuing := bAllowQueuing,
                     firstMove := bFirstMove,
                     stopAfterLastEntry := bStopAfterLastEntry,
+										conditions := aConditionsCopy,
                     posTable := posTable,
                     QA := nQA,
                     lastEntry := bLastEntry,
@@ -83,9 +110,11 @@ CASE io.nSmPosTable OF
       bFirstMove := TRUE;
 
       IF ((io.nMode <> PT_MODE_2 AND io.bRun) OR (io.nMode = PT_MODE_2 AND bOsrStep AND io.bRun)) THEN
+				aConditionsCopy := io.aConditions;
         McePosTableUpdateIndex( allowQueuing := bAllowQueuing,
                                 firstMove := bFirstMove,
                                 stopAfterLastEntry := bStopAfterLastEntry,
+																conditions := aConditionsCopy,
                                 index := io.nIndex,
                                 QA := nQA,
                                 lastEntry := bLastEntry,
@@ -98,10 +127,10 @@ CASE io.nSmPosTable OF
           stConditionResult := McePosTableCheckConditions(
             index := io.nIndex,
             posTableSize := nPosTableSize,
-            conditions := io.aConditions,
+            conditions := aConditionsCopy,
             posTable := posTable);
 
-          IF stConditionResult.bHasConditions THEN
+          IF NOT stConditionResult.bConditionsOk THEN
             io.nSmPosTable := 5;
           ELSE
             io.nSmPosTable := 10;
@@ -120,10 +149,22 @@ CASE io.nSmPosTable OF
       stConditionResult := McePosTableCheckConditions(
         index := io.nIndex,
         posTableSize := nPosTableSize,
-        conditions := io.aConditions,
+        conditions := aConditionsCopy,
         posTable := posTable);
 
       IF stConditionResult.bConditionsOk AND ((io.nMode <> PT_MODE_2 AND io.bRun) OR (bOsrStep OR (nQA > 0))) THEN
+        bWaitBeforeNextEntry := FALSE;
+        McePosTableRecalcQA(allowQueuing := bAllowQueuing,
+          firstMove := bFirstMove,
+          stopAfterLastEntry := bStopAfterLastEntry,
+          conditions := aConditionsCopy,
+          posTable := posTable,
+          QA := nQA,
+          lastEntry := bLastEntry,
+          stopEntry := bStopEntry,
+          waitBeforeNextEntry := bWaitBeforeNextEntry,
+          index := io.nIndex
+          );
         io.nSmPosTable := 10;
       END_IF
     END_IF
@@ -170,6 +211,7 @@ CASE io.nSmPosTable OF
             McePosTableUpdateIndex( allowQueuing := bAllowQueuing,
                                     firstMove := bFirstMove,
                                     stopAfterLastEntry := bStopAfterLastEntry,
+																		conditions := aConditionsCopy,
                                     index := io.nIndex,
                                     QA := nQA,
                                     lastEntry := bLastEntry,
@@ -215,6 +257,7 @@ CASE io.nSmPosTable OF
           McePosTableUpdateIndex( allowQueuing := bAllowQueuing,
                                   firstMove := bFirstMove,
                                   stopAfterLastEntry := bStopAfterLastEntry,
+																	conditions := aConditionsCopy,
                                   index := io.nIndex,
                                   QA := nQA,
                                   lastEntry := bLastEntry,
@@ -242,6 +285,7 @@ CASE io.nSmPosTable OF
       McePosTableUpdateIndex( allowQueuing := bAllowQueuing,
                               firstMove := bFirstMove,
                               stopAfterLastEntry := FALSE,
+															conditions := aConditionsCopy,
                               index := io.nIndex,
                               QA := nQA,
                               lastEntry := bLastEntry,
@@ -333,6 +377,7 @@ FOR i := 0 TO QA_MAX DO
     McePosTableUpdateLoadIndex( allowQueuing := bAllowQueuing,
                                 firstMove := bFirstMove,
                                 stopAfterLastEntry := ((io.nCycleNr + 1) >= io.nNrOfCycles) AND NOT (io.nNrOfCycles = 0),
+																conditions := aConditionsCopy,
                                 index := io.nIndex,
                                 loadIndex := io.nLoadIndex,
                                 QA := nQA,

--- a/source/examples/functions/McePosTable/source.iecst
+++ b/source/examples/functions/McePosTable/source.iecst
@@ -101,6 +101,7 @@ CASE io.nSmPosTable OF
       bFirstMove := TRUE;
 
       IF ((io.nMode <> PT_MODE_2 AND io.bRun) OR (io.nMode = PT_MODE_2 AND bOsrStep AND io.bRun)) THEN
+        io.nLoadIndex := io.nIndex;
         McePosTableUpdateIndex( allowQueuing := bAllowQueuing,
                                 firstMove := bFirstMove,
                                 stopAfterLastEntry := bStopAfterLastEntry,

--- a/source/examples/functions/McePosTable/source.iecst
+++ b/source/examples/functions/McePosTable/source.iecst
@@ -41,7 +41,7 @@ FOR i := 0 TO GVL.CONDITIONS_UBOUND DO
 	
 	IF aOsfConditions[i] THEN
 		aConditionsCopy[i] := FALSE;
-		IF (io.nLoadIndex <> io.nIndex) THEN
+		IF (io.nLoadIndex <> io.nIndex) AND (10 <= io.nSmPosTable AND io.nSmPosTable < 30) THEN
 			nNextIndex := io.nIndex;
       REPEAT
 				aConditionsCopy[i] := aConditionsCopy[i] OR posTable.stEntry[nNextIndex].aStartCondition[i];

--- a/source/examples/functions/McePosTableCheckConditions/source.iecst
+++ b/source/examples/functions/McePosTableCheckConditions/source.iecst
@@ -9,6 +9,6 @@ IF index >= 0 THEN
     stConditionResult.bConditionsOk := stConditionResult.bConditionsOk AND (NOT posTable.stEntry[index].aStartCondition[i] OR (posTable.stEntry[index].aStartCondition[i] AND conditions[i]));
     stConditionResult.aMissingConditions[i] := posTable.stEntry[index].aStartCondition[i] AND NOT conditions[i];
   END_FOR
-END_IF
+END_IF;
 
 McePosTableCheckConditions := stConditionResult;

--- a/source/examples/functions/McePosTableRecalcQA/definition.yaml
+++ b/source/examples/functions/McePosTableRecalcQA/definition.yaml
@@ -31,6 +31,7 @@ var:
       - name: firstMove
       - name: stopAfterLastEntry
       - name: conditions
+      - name: loadIndex
   - kind: in_out
     var:
       - name: posTable

--- a/source/examples/functions/McePosTableRecalcQA/definition.yaml
+++ b/source/examples/functions/McePosTableRecalcQA/definition.yaml
@@ -6,7 +6,7 @@ changelog:
     author: Rioual
     changed:
       - "`conditions` are passed as an input instead of in_out"
-      - "Use `conditiondOK` instead of `hasCondition` for waiting at the next entry"
+      - "Use `conditionsOK` instead of `hasCondition` for waiting at the next entry"
   - version: 0.3.0
     date: 2024-03-28
     author: Rioual

--- a/source/examples/functions/McePosTableRecalcQA/definition.yaml
+++ b/source/examples/functions/McePosTableRecalcQA/definition.yaml
@@ -1,6 +1,12 @@
 author: Rioual
 comment: Recalculate the Queuing Amount
 changelog:
+  - version: 0.4.0
+    date: 2024-05-15
+    author: Rioual
+    changed:
+      - "`conditions` are passed as an input instead of in_out"
+      - "Use `conditiondOK` instead of `hasCondition` for waiting at the next entry"
   - version: 0.3.0
     date: 2024-03-28
     author: Rioual

--- a/source/examples/functions/McePosTableRecalcQA/definition.yaml
+++ b/source/examples/functions/McePosTableRecalcQA/definition.yaml
@@ -24,6 +24,7 @@ var:
       - name: allowQueuing
       - name: firstMove
       - name: stopAfterLastEntry
+      - name: conditions
   - kind: in_out
     var:
       - name: posTable
@@ -58,7 +59,6 @@ var:
       - name: i
       - name: stConditionResult
       - name: nNextIndex
-      - name: aConditions
   - kind: constant
     var:
       - name: QA_MAX

--- a/source/examples/functions/McePosTableRecalcQA/source.iecst
+++ b/source/examples/functions/McePosTableRecalcQA/source.iecst
@@ -4,9 +4,10 @@ nPosTableSize := UINT_TO_INT(SIZEOF(posTable) / SIZEOF(posTable.stEntry[0]));
 // calculate remaining entries until standstill
 // -----------------------------------------------------------------------------
 nEntriesRemaining := McePosTableRemainingEntries( index := index,
+                                                  loadIndex := loadIndex,
                                                   posTableSize := nPosTableSize,
                                                   rollOver := NOT stopAfterLastEntry,
-																									conditions := conditions,
+                                                  conditions := conditions,
                                                   posTable := posTable);
 
 
@@ -27,9 +28,9 @@ IF (nEntriesRemaining <= 0) THEN
       posTableSize := nPosTableSize,
       conditions := conditions,
       posTable := posTable);
-		waitBeforeNextEntry := NOT stConditionResult.bConditionsOk;
-	ELSE
-		waitBeforeNextEntry := FALSE;
+    waitBeforeNextEntry := NOT stConditionResult.bConditionsOk;
+  ELSE
+    waitBeforeNextEntry := FALSE;
   END_IF
   
   IF (posTable.stEntry[index].nActionID > 0) THEN

--- a/source/examples/functions/McePosTableRecalcQA/source.iecst
+++ b/source/examples/functions/McePosTableRecalcQA/source.iecst
@@ -6,6 +6,7 @@ nPosTableSize := UINT_TO_INT(SIZEOF(posTable) / SIZEOF(posTable.stEntry[0]));
 nEntriesRemaining := McePosTableRemainingEntries( index := index,
                                                   posTableSize := nPosTableSize,
                                                   rollOver := NOT stopAfterLastEntry,
+																									conditions := conditions,
                                                   posTable := posTable);
 
 
@@ -16,7 +17,7 @@ lastEntry := FALSE;
 stopEntry := FALSE;
 waitBeforeNextEntry := FALSE;
 IF (nEntriesRemaining <= 0) THEN
-  MEMUtils.MemSet(pbyBuffer := ADR(aConditions), byValue := 0, dwSize := SIZEOF(aConditions));
+  MEMUtils.MemSet(pbyBuffer := ADR(conditions), byValue := 0, dwSize := SIZEOF(conditions));
   MEMUtils.MemSet(pbyBuffer := ADR(stConditionResult), byValue := 0, dwSize := SIZEOF(stConditionResult));
 
   nNextIndex := McePosTableFindEntry(index, 1, nPosTableSize, NOT stopAfterLastEntry, posTable);
@@ -24,10 +25,12 @@ IF (nEntriesRemaining <= 0) THEN
     stConditionResult := McePosTableCheckConditions(
       index := nNextIndex,
       posTableSize := nPosTableSize,
-      conditions := aConditions,
+      conditions := conditions,
       posTable := posTable);
+		waitBeforeNextEntry := NOT stConditionResult.bConditionsOk;
+	ELSE
+		waitBeforeNextEntry := FALSE;
   END_IF
-  waitBeforeNextEntry := stConditionResult.bHasConditions;
   
   IF (posTable.stEntry[index].nActionID > 0) THEN
     stopEntry := TRUE;

--- a/source/examples/functions/McePosTableRecalcQA/source.iecst
+++ b/source/examples/functions/McePosTableRecalcQA/source.iecst
@@ -18,7 +18,6 @@ lastEntry := FALSE;
 stopEntry := FALSE;
 waitBeforeNextEntry := FALSE;
 IF (nEntriesRemaining <= 0) THEN
-  MEMUtils.MemSet(pbyBuffer := ADR(conditions), byValue := 0, dwSize := SIZEOF(conditions));
   MEMUtils.MemSet(pbyBuffer := ADR(stConditionResult), byValue := 0, dwSize := SIZEOF(stConditionResult));
 
   nNextIndex := McePosTableFindEntry(index, 1, nPosTableSize, NOT stopAfterLastEntry, posTable);

--- a/source/examples/functions/McePosTableRecalcQA/source.iecst
+++ b/source/examples/functions/McePosTableRecalcQA/source.iecst
@@ -30,7 +30,7 @@ IF (nEntriesRemaining <= 0) THEN
     waitBeforeNextEntry := NOT stConditionResult.bConditionsOk;
   ELSE
     waitBeforeNextEntry := FALSE;
-  END_IF
+  END_IF;
   
   IF (posTable.stEntry[index].nActionID > 0) THEN
     stopEntry := TRUE;

--- a/source/examples/functions/McePosTableRemainingEntries/definition.yaml
+++ b/source/examples/functions/McePosTableRemainingEntries/definition.yaml
@@ -22,6 +22,7 @@ var:
   - kind: input
     var:
       - name: index
+      - name: loadIndex
       - name: posTableSize
       - name: rollOver
       - name: conditions

--- a/source/examples/functions/McePosTableRemainingEntries/definition.yaml
+++ b/source/examples/functions/McePosTableRemainingEntries/definition.yaml
@@ -37,3 +37,7 @@ var:
         type: INT
       - name: stConditionResult
       - name: nNextIndex
+      - name: nNextLoadIndex
+        type: INT
+      - name: bWaitForConditions
+        type: BOOL

--- a/source/examples/functions/McePosTableRemainingEntries/definition.yaml
+++ b/source/examples/functions/McePosTableRemainingEntries/definition.yaml
@@ -1,6 +1,12 @@
 author: Rioual
 comment: remaining (valid) PosTable entries
 changelog:
+  - version: 0.3.0
+    date: 2024-05-15
+    author: Rioual
+    changed:
+      - "`conditions` are passed as an input instead of in_out"
+      - "Use `conditiondOK` instead of `hasCondition` for waiting at the next entry"
   - version: 0.2.0
     date: 2024-02-29
     author: Rioual

--- a/source/examples/functions/McePosTableRemainingEntries/definition.yaml
+++ b/source/examples/functions/McePosTableRemainingEntries/definition.yaml
@@ -18,6 +18,7 @@ var:
       - name: index
       - name: posTableSize
       - name: rollOver
+      - name: conditions
   - kind: in_out
     var:
       - name: posTable
@@ -29,4 +30,3 @@ var:
         type: INT
       - name: stConditionResult
       - name: nNextIndex
-      - name: aConditions

--- a/source/examples/functions/McePosTableRemainingEntries/source.iecst
+++ b/source/examples/functions/McePosTableRemainingEntries/source.iecst
@@ -28,7 +28,7 @@ FOR i := index TO (posTableSize - 1) DO
         posTable := posTable);
     ELSE
       stConditionResult.bConditionsOk := TRUE;
-    END_IF
+    END_IF;
 
     // entry with standstill action or next entry with conditions, stop searching
     IF (posTable.stEntry[i].nActionID > 0) OR NOT stConditionResult.bConditionsOk THEN
@@ -56,7 +56,7 @@ IF rollOver THEN
           posTableSize := posTableSize,
           conditions := conditions,
           posTable := posTable);
-      END_IF
+      END_IF;
 
       // entry with standstill action or next entry with conditions, stop searching
       IF (posTable.stEntry[i].nActionID > 0) OR NOT stConditionResult.bConditionsOk THEN

--- a/source/examples/functions/McePosTableRemainingEntries/source.iecst
+++ b/source/examples/functions/McePosTableRemainingEntries/source.iecst
@@ -7,6 +7,9 @@ nCount := - 1;
 
 MEMUtils.MemSet(pbyBuffer := ADR(stConditionResult), byValue := 0, dwSize := SIZEOF(stConditionResult));
 
+nNextLoadIndex := McePosTableFindEntry(loadIndex, 1, posTableSize, rollOver, posTable);
+bWaitForConditions := index = nNextLoadIndex;
+
 // -------------------------------------
 // forward direction
 // -------------------------------------
@@ -17,7 +20,7 @@ FOR i := index TO (posTableSize - 1) DO
 
     // check conditions for the next valid position
     nNextIndex := McePosTableFindEntry(i, 1, posTableSize, rollOver, posTable);
-    IF nNextIndex >= 0 AND NOT ((index <= nNextIndex AND nNextIndex <= loadIndex) OR (loadIndex < index AND index < nNextIndex)) THEN
+    IF nNextIndex >= 0 AND NOT ((index <= nNextIndex AND nNextIndex <= loadIndex) OR (loadIndex < index AND index < nNextIndex AND NOT bWaitForConditions)) THEN
       stConditionResult := McePosTableCheckConditions(
         index := nNextIndex,
         posTableSize := posTableSize,
@@ -47,7 +50,7 @@ IF rollOver THEN
 
       // check conditions for the next valid position
       nNextIndex := McePosTableFindEntry(i, 1, posTableSize, FALSE, posTable);
-      IF nNextIndex >= 0 AND NOT ((index <= nNextIndex AND nNextIndex <= loadIndex) OR (loadIndex < index AND index < nNextIndex)) THEN
+      IF nNextIndex >= 0 AND NOT ((index <= nNextIndex AND nNextIndex <= loadIndex) OR (loadIndex < index AND index < nNextIndex AND NOT bWaitForConditions)) THEN
         stConditionResult := McePosTableCheckConditions(
           index := nNextIndex,
           posTableSize := posTableSize,

--- a/source/examples/functions/McePosTableRemainingEntries/source.iecst
+++ b/source/examples/functions/McePosTableRemainingEntries/source.iecst
@@ -5,7 +5,6 @@ END_IF;
 
 nCount := - 1;
 
-MEMUtils.MemSet(pbyBuffer := ADR(aConditions), byValue := 0, dwSize := SIZEOF(aConditions));
 MEMUtils.MemSet(pbyBuffer := ADR(stConditionResult), byValue := 0, dwSize := SIZEOF(stConditionResult));
 
 // -------------------------------------
@@ -22,12 +21,14 @@ FOR i := index TO (posTableSize - 1) DO
       stConditionResult := McePosTableCheckConditions(
         index := nNextIndex,
         posTableSize := posTableSize,
-        conditions := aConditions,
+        conditions := conditions,
         posTable := posTable);
+		ELSE
+			stConditionResult.bConditionsOk := TRUE;
     END_IF
 
     // entry with standstill action or next entry with conditions, stop searching
-    IF (posTable.stEntry[i].nActionID > 0) OR stConditionResult.bHasConditions THEN
+    IF (posTable.stEntry[i].nActionID > 0) OR NOT stConditionResult.bConditionsOk THEN
       McePosTableRemainingEntries := nCount;
       RETURN;
 
@@ -50,12 +51,12 @@ IF rollOver THEN
         stConditionResult := McePosTableCheckConditions(
           index := nNextIndex,
           posTableSize := posTableSize,
-          conditions := aConditions,
+          conditions := conditions,
           posTable := posTable);
       END_IF
 
       // entry with standstill action or next entry with conditions, stop searching
-      IF (posTable.stEntry[i].nActionID > 0) OR stConditionResult.bHasConditions THEN
+      IF (posTable.stEntry[i].nActionID > 0) OR NOT stConditionResult.bConditionsOk THEN
         McePosTableRemainingEntries := nCount;
         RETURN;
 

--- a/source/examples/functions/McePosTableRemainingEntries/source.iecst
+++ b/source/examples/functions/McePosTableRemainingEntries/source.iecst
@@ -17,14 +17,14 @@ FOR i := index TO (posTableSize - 1) DO
 
     // check conditions for the next valid position
     nNextIndex := McePosTableFindEntry(i, 1, posTableSize, rollOver, posTable);
-    IF nNextIndex >= 0 THEN
+    IF nNextIndex >= 0 AND NOT ((index <= nNextIndex AND nNextIndex <= loadIndex) OR (loadIndex < index AND index < nNextIndex)) THEN
       stConditionResult := McePosTableCheckConditions(
         index := nNextIndex,
         posTableSize := posTableSize,
         conditions := conditions,
         posTable := posTable);
-		ELSE
-			stConditionResult.bConditionsOk := TRUE;
+    ELSE
+      stConditionResult.bConditionsOk := TRUE;
     END_IF
 
     // entry with standstill action or next entry with conditions, stop searching
@@ -47,7 +47,7 @@ IF rollOver THEN
 
       // check conditions for the next valid position
       nNextIndex := McePosTableFindEntry(i, 1, posTableSize, FALSE, posTable);
-      IF nNextIndex >= 0 THEN
+      IF nNextIndex >= 0 AND NOT ((index <= nNextIndex AND nNextIndex <= loadIndex) OR (loadIndex < index AND index < nNextIndex)) THEN
         stConditionResult := McePosTableCheckConditions(
           index := nNextIndex,
           posTableSize := posTableSize,

--- a/source/examples/functions/McePosTableUpdateIndex/definition.yaml
+++ b/source/examples/functions/McePosTableUpdateIndex/definition.yaml
@@ -1,6 +1,13 @@
 author: Rioual
 comment: Update the PosTable Index
 changelog:
+  - version: 0.3.0
+    date: 2024-05-15
+    author: Rioual
+    added:
+      - "`conditions` input"
+    changed:
+      - "`QA` is not updated if the conditions are not satisfied for the next entry"
   - version: 0.2.0
     date: 2024-02-29
     author: Rioual

--- a/source/examples/functions/McePosTableUpdateIndex/definition.yaml
+++ b/source/examples/functions/McePosTableUpdateIndex/definition.yaml
@@ -20,6 +20,7 @@ var:
       - name: allowQueuing
       - name: firstMove
       - name: stopAfterLastEntry
+      - name: conditions
   - kind: in_out
     var:
       - name: posTable

--- a/source/examples/functions/McePosTableUpdateIndex/definition.yaml
+++ b/source/examples/functions/McePosTableUpdateIndex/definition.yaml
@@ -28,6 +28,7 @@ var:
       - name: firstMove
       - name: stopAfterLastEntry
       - name: conditions
+      - name: loadIndex
   - kind: in_out
     var:
       - name: posTable

--- a/source/examples/functions/McePosTableUpdateIndex/source.iecst
+++ b/source/examples/functions/McePosTableUpdateIndex/source.iecst
@@ -16,7 +16,7 @@ END_IF;
 // -----------------------------------------------------------------------------
 // calculate Queueing Amount (allowed number of motions to be queued)
 // -----------------------------------------------------------------------------
-IF NOT waitBeforeNextEntry THEN
+IF NOT waitBeforeNextEntry OR firstMove THEN
   McePosTableRecalcQA(allowQueuing := allowQueuing,
                       firstMove := firstMove,
                       stopAfterLastEntry := stopAfterLastEntry,

--- a/source/examples/functions/McePosTableUpdateIndex/source.iecst
+++ b/source/examples/functions/McePosTableUpdateIndex/source.iecst
@@ -16,7 +16,7 @@ END_IF;
 // -----------------------------------------------------------------------------
 // calculate Queueing Amount (allowed number of motions to be queued)
 // -----------------------------------------------------------------------------
-IF NOT waitBeforeNextEntry OR firstMove THEN
+IF (NOT waitBeforeNextEntry OR firstMove) AND (index >= 0) THEN
   McePosTableRecalcQA(allowQueuing := allowQueuing,
                       firstMove := firstMove,
                       stopAfterLastEntry := stopAfterLastEntry,

--- a/source/examples/functions/McePosTableUpdateIndex/source.iecst
+++ b/source/examples/functions/McePosTableUpdateIndex/source.iecst
@@ -20,6 +20,7 @@ IF NOT waitBeforeNextEntry OR firstMove THEN
   McePosTableRecalcQA(allowQueuing := allowQueuing,
                       firstMove := firstMove,
                       stopAfterLastEntry := stopAfterLastEntry,
+                      loadIndex := loadIndex,
                       conditions := conditions,
                       posTable := posTable,
                       QA := QA,

--- a/source/examples/functions/McePosTableUpdateIndex/source.iecst
+++ b/source/examples/functions/McePosTableUpdateIndex/source.iecst
@@ -16,13 +16,16 @@ END_IF;
 // -----------------------------------------------------------------------------
 // calculate Queueing Amount (allowed number of motions to be queued)
 // -----------------------------------------------------------------------------
-McePosTableRecalcQA(allowQueuing := allowQueuing,
-                    firstMove := firstMove,
-                    stopAfterLastEntry := stopAfterLastEntry,
-                    posTable := posTable,
-                    QA := QA,
-                    lastEntry := lastEntry,
-                    stopEntry := stopEntry,
-                    waitBeforeNextEntry := waitBeforeNextEntry,
-                    index := index
-                    );
+IF NOT waitBeforeNextEntry THEN
+  McePosTableRecalcQA(allowQueuing := allowQueuing,
+                      firstMove := firstMove,
+                      stopAfterLastEntry := stopAfterLastEntry,
+                      conditions := conditions,
+                      posTable := posTable,
+                      QA := QA,
+                      lastEntry := lastEntry,
+                      stopEntry := stopEntry,
+                      waitBeforeNextEntry := waitBeforeNextEntry,
+                      index := index
+                      );
+END_IF;

--- a/source/examples/functions/McePosTableUpdateLoadIndex/definition.yaml
+++ b/source/examples/functions/McePosTableUpdateLoadIndex/definition.yaml
@@ -1,6 +1,11 @@
 author: Rioual
 comment: Update the PosTable LoadIndex; for sending next motion
 changelog:
+  - version: 0.4.0
+    date: 2024-05-15
+    author: Rioual
+    added:
+      - "`conditions` input"
   - version: 0.3.0
     date: 2024-03-28
     author: Rioual

--- a/source/examples/functions/McePosTableUpdateLoadIndex/definition.yaml
+++ b/source/examples/functions/McePosTableUpdateLoadIndex/definition.yaml
@@ -29,6 +29,7 @@ var:
           The *PosTable* index to update the `LoadIndex` from.
         type: INT
         comment: PosTable index for current motion
+      - name: conditions
   - kind: in_out
     var:
       - name: posTable

--- a/source/examples/functions/McePosTableUpdateLoadIndex/source.iecst
+++ b/source/examples/functions/McePosTableUpdateLoadIndex/source.iecst
@@ -33,6 +33,7 @@ IF firstMove AND allowQueuing THEN
   nEntriesRemaining := McePosTableRemainingEntries( index := index,
                                                     posTableSize := nPosTableSize,
                                                     rollOver := NOT stopAfterLastEntry,
+																										conditions := conditions,
                                                     posTable := posTable);
 
   // -------------------------------------

--- a/source/examples/functions/McePosTableUpdateLoadIndex/source.iecst
+++ b/source/examples/functions/McePosTableUpdateLoadIndex/source.iecst
@@ -31,9 +31,10 @@ IF firstMove AND allowQueuing THEN
   // calculate remaining entries until standstill
   // -------------------------------------
   nEntriesRemaining := McePosTableRemainingEntries( index := index,
+                                                    loadIndex := loadIndex,
                                                     posTableSize := nPosTableSize,
                                                     rollOver := NOT stopAfterLastEntry,
-																										conditions := conditions,
+                                                    conditions := conditions,
                                                     posTable := posTable);
 
   // -------------------------------------

--- a/source/examples/functions/_common.yaml
+++ b/source/examples/functions/_common.yaml
@@ -80,6 +80,11 @@ var:
       Index to start the search from.
     type: INT
     comment: index of actual PosTable entry
+  loadIndex:
+    description: |
+      Index of the last loaded motion.
+    type: INT
+    comment: index for loading next motion(s)
   posTableMode:
     description: |
       *PosTable* operation mode.

--- a/source/examples/functions/_common.yaml
+++ b/source/examples/functions/_common.yaml
@@ -131,7 +131,7 @@ var:
       "1" : "`QA` is updated depending on the number of remaining entries until standstill"
   conditions:
     description: |
-      Bits which can be used as start conditions for a PosTable entry.
+      Bits used as start conditions for a PosTable entry.
       
       If a PosTable entry has one or more bits in `startConditions` set to `TRUE`
       then the motion for that entry will not be started until the start conditions
@@ -141,7 +141,7 @@ var:
       - If you need a condition to be checked for the `FALSE` state, 
         you need to invert the connected signal outside of PosTable
     type: ARRAY [0..GVL.CONDITIONS_UBOUND] OF BOOL
-    comment: Bits which can be used as start conditions for a PosTable entry
+    comment: bits used as start conditions for a PosTable entry
   stConditionResult:
     description: |
       `bConditionsOk` informs if the conditions of the next motion are satisfied.

--- a/source/examples/types/MceStateMonitoringData/definition.yaml
+++ b/source/examples/types/MceStateMonitoringData/definition.yaml
@@ -1,8 +1,8 @@
 company: Yaskawa Europe GmbH
 author: Rioual
-comment: Datatype for PosTable entry
+comment: data for state machine monitoring
 changelog:
-  - version: 0.1.0
+  - version: 0.1.1
     date: 2024-02-06
     author: Rioual
     added:


### PR DESCRIPTION
This implements step 2 of #31.

> In step 1, the start condition mechanism _always_ scheduled a standstill (and transition in the waiting state), even if conditions were already satisfied.
For many use cases, that is ugly as conditions are often satisfied in time but the robot motion will still have a short standstill.

This step 2 adds the functionality to prevent such short standstills. It will continuously monitor the conditions of the entry which would be next in line to send.

If those conditions change to positive (`not ok -> ok`), the QA will be recalculated, causing the next motion to be sent. A later change back to negative (`ok -> not ok`) has no effect.

For an entry with start conditions, if the corresponding condition changes back to negative (`ok -> not ok`) while the LoadIndex is greater than the entry index, it does not result in a stop. Already queued motions cannot be removed by PosTable.

## Code changes

### Update `McePosTable` function

- Recalculate QA if conditions change to positive
- Recalculate QA if conditions change to negative and changed conditions are not used in entries between `index` and `loadIndex` (included)
- Recalculate QA when leaving state 5 (wait for conditions)

### Update `McePosTableRecalcQA` and `McePosTableRemainingEntries`

- Add a `conditions` input
- Consider an entry as a waitEntry if this entry has conditions that are not satisfied. To do so, replace `stConditionResult.bHasConditions` by `NOT stConditionResult.bConditionsOk`

### Update `McePosTableUpdateIndex` function

- Add a `conditions` input
- Do not update QA if `waitBeforeNextEntry` is `True`

### Update `McePosTableUpdateLoadIndex` function

- Add a `conditions` input
