### PR TITLE
Bug/38 wait for step with step by step

### DIFF
--- a/source/examples/functions/McePosTable/definition.yaml
+++ b/source/examples/functions/McePosTable/definition.yaml
@@ -1,6 +1,11 @@
 author: Rioual
 comment: Performed a trajectory stored in a PosTable
 changelog:
+  - version: 0.6.0
+    date: 2024-09-30
+    author: Rioual
+    fixed:
+      - State machine stuck if `nMode = 2` and `WAIT_FOR_STEP` actionID is active
   - version: 0.5.0
     date: 2024-09-30
     author: Rioual

--- a/source/examples/functions/McePosTable/definition.yaml
+++ b/source/examples/functions/McePosTable/definition.yaml
@@ -6,7 +6,7 @@ changelog:
     author: Rioual
     fixed:
       - State machine stuck if `nMode = 2` and `WAIT_FOR_STEP` actionID is active
-      - Motion and actionID are run again if servos are disabled then enabled
+      - Motion and actionID no longer being re-executed after recovery of `bSystemReady`
   - version: 0.5.0
     date: 2024-09-30
     author: Rioual

--- a/source/examples/functions/McePosTable/definition.yaml
+++ b/source/examples/functions/McePosTable/definition.yaml
@@ -1,6 +1,11 @@
 author: Rioual
 comment: Performed a trajectory stored in a PosTable
 changelog:
+  - version: 0.5.0
+    date: 2024-09-30
+    author: Rioual
+    changed:
+      - "Correct `bMoveType` name to `nMoveType` to respect the naming convention"
   - version: 0.4.0
     date: 2024-05-15
     author: Rioual

--- a/source/examples/functions/McePosTable/definition.yaml
+++ b/source/examples/functions/McePosTable/definition.yaml
@@ -6,6 +6,7 @@ changelog:
     author: Rioual
     fixed:
       - State machine stuck if `nMode = 2` and `WAIT_FOR_STEP` actionID is active
+      - Motion and actionID are run twice if servos are disabled then enabled
   - version: 0.5.0
     date: 2024-09-30
     author: Rioual

--- a/source/examples/functions/McePosTable/definition.yaml
+++ b/source/examples/functions/McePosTable/definition.yaml
@@ -6,7 +6,7 @@ changelog:
     author: Rioual
     fixed:
       - State machine stuck if `nMode = 2` and `WAIT_FOR_STEP` actionID is active
-      - Motion and actionID are run twice if servos are disabled then enabled
+      - Motion and actionID are run again if servos are disabled then enabled
   - version: 0.5.0
     date: 2024-09-30
     author: Rioual

--- a/source/examples/functions/McePosTable/source.iecst
+++ b/source/examples/functions/McePosTable/source.iecst
@@ -381,7 +381,7 @@ FOR i := 0 TO QA_MAX DO
                                 loadIndex := io.nLoadIndex,
                                 QA := nQA,
                                 posTable := posTable);
-    aUseMoveType[i] := posTable.stEntry[io.nLoadIndex].bMoveType;
+    aUseMoveType[i] := posTable.stEntry[io.nLoadIndex].nMoveType;
 
     IF aUseMoveType[i] = 1 THEN
       // -------------------------------------

--- a/source/examples/functions/McePosTable/source.iecst
+++ b/source/examples/functions/McePosTable/source.iecst
@@ -31,7 +31,7 @@ bStopAfterLastEntry := ((io.nCycleNr + 1) >= io.nNrOfCycles) AND NOT (io.nNrOfCy
 bUpdateQA := FALSE;
 IF (io.nMode = PT_MODE_0) AND (nQA < QA_MAX) THEN
   nNextValidLoadIndex := McePosTableFindEntry(io.nLoadIndex, 1, nPosTableSize, NOT bStopAfterLastEntry, posTable);
-  IF nNextValidLoadIndex >= 0 THEN
+  IF nNextValidLoadIndex >= 0 AND posTable.stEntry[io.nLoadIndex].nActionID = 0 THEN
     stConditionResult := McePosTableCheckConditions(
       index := nNextValidLoadIndex,
       posTableSize := nPosTableSize,
@@ -54,7 +54,7 @@ END_IF;
 io.bError := FALSE;
 
 // Update QA
-bUpdateQA := bUpdateQA OR bOsrRecalcQA OR bOsrSystemReady;
+bUpdateQA := bUpdateQA OR bOsrRecalcQA OR (bOsrSystemReady AND io.nSmPosTable >= 10 AND io.nSmPosTable < 30);
 IF bUpdateQA THEN
   bFirstMove := bFirstMove OR bOsrSystemReady OR bOsrRun; // only if first move after standstill
   McePosTableRecalcQA(allowQueuing := bAllowQueuing,

--- a/source/examples/functions/McePosTable/source.iecst
+++ b/source/examples/functions/McePosTable/source.iecst
@@ -240,7 +240,20 @@ CASE io.nSmPosTable OF
     ELSIF io.bSystemReady THEN
       bWaiting := (bDefaultActionDone OR io.bCustomActionDone) AND (io.nMode = PT_MODE_2);
       bCustomActionDone := io.bCustomActionDone AND (io.nActionID > RESERVED_ACTIONID_UBOUND);
-      IF (bDefaultActionDone OR bCustomActionDone) AND ((io.nMode <> PT_MODE_2) OR bOsrStep) THEN
+      IF bDefaultActionDone OR bCustomActionDone THEN
+        io.nSmPosTable := 32;
+      END_IF;
+    END_IF;
+
+  // -------------------------------------
+  // state 32 - waiting after performing action
+  // -------------------------------------
+  32:
+    IF NOT io.bRun THEN
+      io.nSmPosTable := 50;
+    ELSIF io.bSystemReady THEN
+      bWaiting := (io.nMode = PT_MODE_2);
+      IF (io.nMode <> PT_MODE_2) OR bOsrStep THEN
         IF bLastEntry AND (io.nNrOfCycles - io.nCycleNr <= 1) THEN
           io.nSmPosTable := 40;
         ELSE

--- a/source/examples/types/McePosTableEntry/definition.yaml
+++ b/source/examples/types/McePosTableEntry/definition.yaml
@@ -2,6 +2,11 @@ company: Yaskawa Europe GmbH
 author: Rioual
 comment: Datatype for a PosTable entry
 changelog:
+  - version: 0.3.0
+    date: 2024-09-30
+    author: Rioual
+    changed:
+      - "Correct `bMoveType` name to `nMoveType` to respect the naming convention"
   - version: 0.2.0
     date: 2024-03-28
     author: Rioual
@@ -89,7 +94,7 @@ var:
       The speed unit depends on the [`nSpeedUnits`](#nspeedunits) parameter.
     type: REAL
     comment: "[% from max] for SpeedUnits=0 / [absolute units (mm/sec and deg/sec)] for SpeedUnits=1 / [50-100% from VMAX] for SpeedUnits=2 (n/a for DX200)"
-  - name: bMoveType
+  - name: nMoveType
     description: |
       Specifies the type of movement for the entry.
     type: SINT


### PR DESCRIPTION
Fixes #38 

Also fixes a bug where a motion and its actionID run a second time if servos are disabled then enabled while the actionID was running.