### PR TITLE
Various improvements and fixes for mce start stop

### DIFF
--- a/source/examples/functions/MceStartStop/definition.yaml
+++ b/source/examples/functions/MceStartStop/definition.yaml
@@ -6,6 +6,7 @@ changelog:
     author: Rioual
     added:
       - transition to state 0 if servos are disabled by the robot controller
+      - reset after stop
     changed:
       - add check for system state to prevent flipping between states
   - version: 0.2.0

--- a/source/examples/functions/MceStartStop/definition.yaml
+++ b/source/examples/functions/MceStartStop/definition.yaml
@@ -10,6 +10,7 @@ changelog:
     changed:
       - add check for system state to prevent flipping between states
       - Avoid error if teach pendant key switch is not in remote mode
+      - Adapt to `MceStartStopIO` version `0.3.0` update
   - version: 0.2.0
     date: 2022-02-23
     author: deGroot
@@ -72,11 +73,15 @@ var:
         type: BOOL
         comment: rising edge
 
+      - name: bOsrHoldRestart
+        type: BOOL
+        comment: rising edge
+
       - name: bOsrFlush
         type: BOOL
         comment: rising edge
 
-      - name: bOsrSystemReady
+      - name: bOsrServoOn
         type: BOOL
         comment: rising edge
 
@@ -85,5 +90,5 @@ var:
         comment: external- and internal conditions ok
 
       - name: aOneShots
-        type: ARRAY [0..3] OF BOOL
+        type: ARRAY [0..4] OF BOOL
         comment: bits for one shot signals

--- a/source/examples/functions/MceStartStop/definition.yaml
+++ b/source/examples/functions/MceStartStop/definition.yaml
@@ -9,6 +9,7 @@ changelog:
       - reset after stop
     changed:
       - add check for system state to prevent flipping between states
+      - Avoid error if teach pendant key switch is not in remote mode
   - version: 0.2.0
     date: 2022-02-23
     author: deGroot

--- a/source/examples/functions/MceStartStop/definition.yaml
+++ b/source/examples/functions/MceStartStop/definition.yaml
@@ -1,6 +1,11 @@
 author: Rioual
 comment: Start/stop logic + speed override
 changelog:
+  - version: 1.0.0
+    date: 2024-12-13
+    author: Rioual
+    changed:
+      - add check for system state to prevent flipping between states
   - version: 0.2.0
     date: 2022-02-23
     author: deGroot

--- a/source/examples/functions/MceStartStop/definition.yaml
+++ b/source/examples/functions/MceStartStop/definition.yaml
@@ -5,12 +5,12 @@ changelog:
     date: 2024-12-16
     author: Rioual
     added:
-      - transition to state 0 if servos are disabled by the robot controller
+      - reset the state machine if servos are disabled by the robot controller
       - reset after stop
     changed:
+      - requires `MceStartStopIO` data type version `0.3.0`
       - add check for system state to prevent flipping between states
-      - Avoid error if teach pendant key switch is not in remote mode
-      - Adapt to `MceStartStopIO` version `0.3.0` update
+      - avoid error if teach pendant key switch is not in remote mode
   - version: 0.2.0
     date: 2022-02-23
     author: deGroot

--- a/source/examples/functions/MceStartStop/definition.yaml
+++ b/source/examples/functions/MceStartStop/definition.yaml
@@ -2,8 +2,10 @@ author: Rioual
 comment: Start/stop logic + speed override
 changelog:
   - version: 1.0.0
-    date: 2024-12-13
+    date: 2024-12-16
     author: Rioual
+    added:
+      - transition to state 0 if servos are disabled by the robot controller
     changed:
       - add check for system state to prevent flipping between states
   - version: 0.2.0

--- a/source/examples/functions/MceStartStop/index.md
+++ b/source/examples/functions/MceStartStop/index.md
@@ -45,6 +45,7 @@ to your HMI and/or to higher level state machines.
 // this is just a portion of the relevant signals
 GVL.stStartStop[0].bStart := ...;
 GVL.stStartStop[0].bStop := ...;
+GVL.stStartStop[0].bHoldRestart := ;
 GVL.stStartStop[0].fSpeedOverride := ...;
 GVL.stStartStop[0].bExternalConditionsOk := ...;
 ```
@@ -67,7 +68,7 @@ to your HMI and/or to higher level state machines.
 
 ```iecst
 // this is just a portion of the relevant signals
-... := GVL.stStartStop[0].bStartIndicator;
-... := GVL.stStartStop[0].bStopIndicator;
-... := GVL.stStartStop[0].bSystemReady;
+... := GVL.stStartStop[0].bServoOn;
+... := GVL.stStartStop[0].bIdle;
+... := GVL.stStartStop[0].bHoldActive;
 ```

--- a/source/examples/functions/MceStartStop/source.iecst
+++ b/source/examples/functions/MceStartStop/source.iecst
@@ -122,6 +122,10 @@ CASE io.nSmStartStop OF
       io.nSmStartStop := 60;
     END_IF;
 
+    IF MLX.Signals.AllDrivesDisabled THEN
+      io.nSmStartStop := 0;
+    END_IF;
+
   // -------------------------------------
   // hold motion with MLxHold
   // -------------------------------------
@@ -152,6 +156,10 @@ CASE io.nSmStartStop OF
 
     IF bOsrStop OR NOT bAllConditionsOk THEN
       io.nSmStartStop := 60;
+    END_IF;
+
+    IF MLX.Signals.AllDrivesDisabled THEN
+      io.nSmStartStop := 0;
     END_IF;
 
   // -------------------------------------

--- a/source/examples/functions/MceStartStop/source.iecst
+++ b/source/examples/functions/MceStartStop/source.iecst
@@ -22,8 +22,10 @@ bOsrStop := io.bStop AND NOT aOneShots[1];
 aOneShots[1] := io.bStop;
 bOsrFlush:= io.bFlush AND NOT aOneShots[2];
 aOneShots[2] := io.bFlush;
-bOsrSystemReady:= io.bSystemReady AND NOT aOneShots[3];
-aOneShots[3] := io.bSystemReady;
+bOsrServoOn:= io.bServoOn AND NOT aOneShots[3];
+aOneShots[3] := io.bServoOn;
+bOsrHoldRestart:= io.bHoldRestart AND NOT aOneShots[4];
+aOneShots[4] := io.bHoldRestart;
 
 bAllConditionsOk :=
   io.bExternalConditionsOk AND
@@ -104,7 +106,7 @@ CASE io.nSmStartStop OF
   // -------------------------------------
   30:
     // Hold initiated by start button
-    IF bOsrStart AND (MLX.SystemState = 4) THEN
+    IF bOsrHoldRestart AND (MLX.SystemState = 4) THEN
         io.nSmStartStop := 35;
     END_IF;
 
@@ -145,7 +147,7 @@ CASE io.nSmStartStop OF
   // -------------------------------------
   40:
     // Restart initiated by start button
-    IF bOsrStart THEN
+    IF bOsrHoldRestart AND (MLX.NumberOfQueuedErrors = 0) THEN
         io.nSmStartStop := 45;
     END_IF;
 
@@ -250,7 +252,7 @@ END_CASE;
 // -----------------------------------------------------------------------------
 // outputs
 // -----------------------------------------------------------------------------
-io.bSystemReady :=
+io.bServoOn :=
   (io.nSmStartStop = 30) OR
   (io.nSmStartStop = 35) OR
   (io.nSmStartStop = 40) OR
@@ -259,46 +261,11 @@ io.bSystemReady :=
   (io.nSmStartStop = 51) OR
   (io.nSmStartStop = 60);
 
-// stop indicator
-CASE io.nSmStartStop OF
-  0,
-  1:
-    io.bStopIndicator := TRUE;
+io.bIdle :=
+  (io.nSmStartStop = 0) OR
+  (io.nSmStartStop = 1);
 
-  60:
-    io.bStartIndicator := blinkSignals.bSlow;
-
-  70:
-    io.bStopIndicator := blinkSignals.bFast;
-
-  ELSE
-    io.bStopIndicator := FALSE;
-
-END_CASE;
-
-// start indicator
-CASE io.nSmStartStop OF
-  1:
-    io.bStartIndicator := blinkSignals.bDoubleFlash;
-
-  10,
-  20,
-  35,
-  45,
-  50:
-    io.bStartIndicator := blinkSignals.bFast;
-
-  30:
-    io.bStartIndicator := TRUE;
-
-  40:
-    io.bStartIndicator := blinkSignals.bSlow;
-
-  ELSE
-    io.bStartIndicator := FALSE;
-
-END_CASE;
-
+io.bHoldActive := (io.nSmStartStop = 40);
 
 // -----------------------------------------------------------------------------
 // State machine: speed override
@@ -309,7 +276,7 @@ CASE io.nSmSpeedOverride OF
   // -------------------------------------
   0:
     fbIdletime.IN := TRUE;
-    IF fbIdletime.Q AND io.bSystemReady
+    IF fbIdletime.Q AND io.bServoOn
       AND (io.fSpeedOverride <> fSpeedOverrideStored) THEN
       fSpeedOverrideStored := io.fSpeedOverride;
       io.nErrorCode := 0;
@@ -340,7 +307,7 @@ CASE io.nSmSpeedOverride OF
 END_CASE;
 
 // send speed override at every rising edge of system ready
-IF bOsrSystemReady THEN
+IF bOsrServoOn THEN
   fSpeedOverrideStored := -1;
 END_IF;
 

--- a/source/examples/functions/MceStartStop/source.iecst
+++ b/source/examples/functions/MceStartStop/source.iecst
@@ -189,7 +189,21 @@ CASE io.nSmStartStop OF
         io.nErrorCode := 1000 + io.nSmStartStop;
         io.nSmStartStop := 70;
       ELSE
-        io.nSmStartStop := 45;
+        io.nSmStartStop := 51;
+      END_IF;
+    END_IF;
+
+  // -------------------------------------
+  // reset system with MLxReset
+  // -------------------------------------
+  51:
+    fbReset.Enable := TRUE;
+    IF fbReset.Sts_EN AND fbReset.Sts_DN THEN
+      IF fbReset.Sts_ER THEN
+        io.nErrorCode := 1000 + io.nSmStartStop;
+        io.nSmStartStop := 70;
+      ELSE
+        io.nSmStartStop := 30;
       END_IF;
     END_IF;
 
@@ -237,6 +251,8 @@ io.bSystemReady :=
   (io.nSmStartStop = 35) OR
   (io.nSmStartStop = 40) OR
   (io.nSmStartStop = 45) OR
+  (io.nSmStartStop = 50) OR
+  (io.nSmStartStop = 51) OR
   (io.nSmStartStop = 60);
 
 // stop indicator

--- a/source/examples/functions/MceStartStop/source.iecst
+++ b/source/examples/functions/MceStartStop/source.iecst
@@ -218,15 +218,19 @@ CASE io.nSmStartStop OF
   // abort motion and disable system with MLxAbort
   // -------------------------------------
   70:
-    fbAbort.Enable := TRUE;
-    IF fbAbort.Sts_EN AND fbAbort.Sts_DN AND (MLX.SystemState <> 7) THEN
-      IF fbAbort.Sts_ER OR (io.nErrorCode > 0) THEN
-        IF (io.nErrorCode = 0) THEN
-          io.nErrorCode := 1000 + io.nSmStartStop;
+    IF NOT MLX.Signals.MLXGatewayConnected OR NOT MLX.Signals.RemoteMode THEN
+      io.nSmStartStop := 0;
+    ELSE
+      fbAbort.Enable := TRUE;
+      IF fbAbort.Sts_EN AND fbAbort.Sts_DN AND (MLX.SystemState <> 7) THEN
+        IF fbAbort.Sts_ER OR (io.nErrorCode > 0) THEN
+          IF (io.nErrorCode = 0) THEN
+            io.nErrorCode := 1000 + io.nSmStartStop;
+          END_IF;
+          io.nSmStartStop := 99;
+        ELSE
+          io.nSmStartStop := 0;
         END_IF;
-        io.nSmStartStop := 99;
-      ELSE
-        io.nSmStartStop := 0;
       END_IF;
     END_IF;
 

--- a/source/examples/functions/MceStartStop/source.iecst
+++ b/source/examples/functions/MceStartStop/source.iecst
@@ -164,7 +164,9 @@ CASE io.nSmStartStop OF
         io.nErrorCode := 1000 + io.nSmStartStop;
         io.nSmStartStop := 70;
       ELSE
-        io.nSmStartStop := 30;
+        IF (MLX.SystemState <> 6) THEN
+          io.nSmStartStop := 30;
+        END_IF;
       END_IF;
     END_IF;
 

--- a/source/examples/types/MceStartStopIO/definition.yaml
+++ b/source/examples/types/MceStartStopIO/definition.yaml
@@ -136,6 +136,7 @@ var:
       "40": system held (restart with start button)
       "45": restart motion with MLxRestart
       "50": stop and flush buffered motions with MLxStop
+      "51": reset system with MLxReset
       "60": finish buffered motions
       "70": abort motion and disable system with MLxAbort
       "99": state machine error

--- a/source/examples/types/MceStartStopIO/definition.yaml
+++ b/source/examples/types/MceStartStopIO/definition.yaml
@@ -2,6 +2,19 @@ company: Yaskawa Europe GmbH
 author: Rioual
 comment: IO data for the MceStartStop function
 changelog:
+  - version: 1.0.0
+    date: 2024-12-12
+    author: Rioual
+    added:
+      - Input `bHold`
+      - Output `bHoldActive`
+    changed:
+      - Rename `bSystemReady` to `bServoOn`
+      - Output `bServoOn` is now TRUE at state 50
+      - Rename `bStopIndicator` to `bSystemStopped`
+    removed:
+      - Output `bStartIndicator`
+      - blinking behavior on `bSystemStopped`
   - version: 0.2.0
     date: 2022-02-23
     author: deGroot
@@ -38,13 +51,13 @@ var:
     description: |
       *Used as input*
 
-      A rising edge of this input will *start/hold/restart* the system.
+      A rising edge of this input will *start* the system by enabling the servos.
 
       This input can be connected to an HMI momentary button and if applicable,
       to a higher level state machine (e.g. machine operating mode).
     type: BOOL
     default_value: "0"
-    comment: "input: start/hold/restart (uses rising edge)"
+    comment: "input: enable the servos (uses rising edge)"
 
   - name: bStop
     description: |
@@ -57,6 +70,21 @@ var:
     type: BOOL
     default_value: "0"
     comment: "input: stop/abort (uses rising edge)"
+
+  - name: bHoldRestart
+    description: |
+      *Used as input*
+
+      A rising edge of this input will *hold/restart* the system.
+      If the robot is moving, a rising edge on this signal will hold the trajectory.
+      If the robot is in held state (`bHoldActive = TRUE`), a rising edge will
+      resume the trajectory.
+
+      This input can be connected to an HMI momentary button and if applicable,
+      to a higher level state machine (e.g. machine operating mode).
+    type: BOOL
+    default_value: "0"
+    comment: "input: hold/restart (uses rising edge)"
 
   - name: bFlush
     description: |
@@ -73,48 +101,46 @@ var:
     default_value: "0"
     comment: "input: stop and flush the motion queue (uses rising edge)"
 
-  - name: bSystemReady
+  - name: bServoOn
     description: |
       *Used as output*
 
-      This tells the system is ready for processing motion commands.
+      State machine is in *servo on* state.
+
+      This tells the servos are enabled.
+      The system is ready for processing motion commands.
 
       This output can be used as condition by lower level state machines which
       issue motion commands (e.g. PosTable).
 
     type: BOOL
-    comment: "output: system ready for processing motion commands"
+    comment: "output: state machine: servo on. Servos are enabled and system is ready for processing motion commands"
 
-  - name: bStartIndicator
+  - name: bIdle
     description: |
       *Used as output*
 
-      Connect this signal to the indicator light of the *start button*.
+      State machine is in *idle* state.
+
+      The robot controller servos are off.
     type: BOOL
     comment: |
-      output: indicator for start button
-      (on: system ready, blink slow: waiting for user,
-      blink fast: busy, double flash: start ready)
-    legend:
-      "1) double flash": start ready
-      "2) slow blinking": waiting for user (press start to continue)
-      "3) on": system ready
-      "4) fast blinking": startup commands busy
+      output: state machine: idle. Robot controller servos are off
 
-  - name: bStopIndicator
+  - name: bHoldActive
     description: |
       *Used as output*
 
-      Connect this signal to the indicator light of the *stop button*.
+      State machine is in *hold* state.
+
+      The robot controller is in Held mode.
+      
+      The servos are ON and the trajectory is paused.
+
+      The trajectory can be resumed with a rising edge on `bHoldRestart`.
     type: BOOL
     comment: |
-      output: indicator for stop button
-      (on: system off, blink slow: finishing motions,
-      blink fast: busy)
-    legend:
-      "1) on": system switched off
-      "2) slow blinking": finishing motions
-      "3) fast blinking": stop commands busy
+      output: state machine: held. Trajectory is suspended
 
   - name: bError
   - name: nErrorCode

--- a/source/examples/types/MceStartStopIO/definition.yaml
+++ b/source/examples/types/MceStartStopIO/definition.yaml
@@ -2,7 +2,7 @@ company: Yaskawa Europe GmbH
 author: Rioual
 comment: IO data for the MceStartStop function
 changelog:
-  - version: 1.0.0
+  - version: 0.3.0
     date: 2024-12-12
     author: Rioual
     added:
@@ -137,7 +137,7 @@ var:
       
       The servos are ON and the trajectory is paused.
 
-      The trajectory can be resumed with a rising edge on `bHoldRestart`.
+      The trajectory can be resumed with a rising edge on [`bHoldRestart`](#bholdrestart).
     type: BOOL
     comment: |
       output: state machine: held. Trajectory is suspended


### PR DESCRIPTION
This implement several improvements and bug fixes of `MceStartStop`:

- Fix that if servos are disabled by the robot controller, the `MceStartStop` adapts to this situation (#55)
- Avoids the command buffer to be filled up over time due to abruptly aborted commands (#26)
- Avoid error on `MLxAbort` when quitting the remote mode, or when the robot controller is disconnected (#57)
- Avoid loop on slow system when resuming a trajectory from the *Held* state (#60)
- Add and rename IOs of `MceStartStop` to make integration of `MceStartStop` easier with upper-level state machine (#48)

# Code changes

## Update `MceStartStopIO` data type

- Add a `bHoldRestart` input to hold or resume a trajectory
- Add a `bHoldActive` output
- Rename `bSystemReady` output to `bServoOn`. This output is usually connected to other MCE FB's `bSystemReady` input. Their name will be updated in a future release
- Rename `bSystemStopped` to `bIdle` to match other MCE FBs

Blinking behavior on all outputs are removed.

All these updates are related to #48.

## Update `MceStartStop`

- Integrate evolutions of `MceStartStopIO` data type (#48)
- If servos are disabled on the robot controller (Pendant key switch set from *remote* to *teach* mode, collision alarm, ...), the state machine adapts accordingly (#55)
- Add a `MLxReset` after the `MLxStop` when `bFlush` input is activated(#26)
- Avoid running the `MLxAbort` command when remote mode is not selected or when the robot controller is disconnected (#57)
- When resuming a trajectory from the *Held* state, check if the `SystemState` is not in the *Held* state anymore (#60)