### PR TITLE
Feature/61 Jog to point function in `MceManualMotion`

### DIFF
--- a/source/examples/functions/MceManualMotion/definition.yaml
+++ b/source/examples/functions/MceManualMotion/definition.yaml
@@ -6,7 +6,7 @@ changelog:
     date: 2024-12-24
     author: Rioual
     added:
-      - jog to point
+      - jog to point function
   - version: 0.2.0
     date: 2024-12-20
     author: Rioual

--- a/source/examples/functions/MceManualMotion/definition.yaml
+++ b/source/examples/functions/MceManualMotion/definition.yaml
@@ -2,6 +2,11 @@ company: Yaskawa Europe GmbH
 author: deGroot
 comment: Handling the manual motion.
 changelog:
+  - version: 0.3.0
+    date: 2024-12-24
+    author: Rioual
+    added:
+      - jog to point
   - version: 0.2.0
     date: 2024-12-20
     author: Rioual
@@ -141,11 +146,23 @@ var:
       - name: fbMoveLinRel
         type: MLxRobotMoveLinearRelative
 
+      - name: fbMoveAxisAbsolute
+        type: MLxRobotMoveAxisAbsolute
+
+      - name: fbMoveLinearAbsolute
+        type: MLxRobotMoveLinearAbsolute
+
+      - name: fbStop
+        type: MLxStop
+
       - name: fbIdleTime
         type: TON
 
       - name: fbCoastTime
         type: TON
+
+      - name: stTargetPoint
+        type: MLxAppDataTeachPoint
 
   - kind: constant
     var:
@@ -173,6 +190,11 @@ var:
         type: REAL
         comment: "inching speed [% rated]"
         default_value: "10"
+
+      - name: JOG_TO_BF
+        type: SINT
+        comment: "BlendFactor for jog to point [-1 to 8]"
+        default_value: "0"
 
       - name: INCHING_BF
         type: SINT

--- a/source/examples/functions/MceManualMotion/definition.yaml
+++ b/source/examples/functions/MceManualMotion/definition.yaml
@@ -2,6 +2,11 @@ company: Yaskawa Europe GmbH
 author: deGroot
 comment: Handling the manual motion.
 changelog:
+  - version: 0.2.0
+    date: 2024-12-20
+    author: Rioual
+    changed:
+      - avoid abruptly interrupted command when `bSystemReady` turns `False`
   - version: 0.1.0
     date: 2022-04-14
     author: deGroot

--- a/source/examples/functions/MceManualMotion/definition.yaml
+++ b/source/examples/functions/MceManualMotion/definition.yaml
@@ -7,6 +7,8 @@ changelog:
     author: Rioual
     added:
       - jog to point function
+    changed:
+      - requires `MceManualMotionIO` data type version `0.2.0`
   - version: 0.2.0
     date: 2024-12-20
     author: Rioual

--- a/source/examples/functions/MceManualMotion/index.md
+++ b/source/examples/functions/MceManualMotion/index.md
@@ -19,6 +19,7 @@ motions are required.
 - Jog TCP (cartesian motion)
 - Inching axis
 - Inching TCP
+- Jog to point
 - Handles the switching of `MLX.JoggingMode`.
 - Activates the selected Tool and User Frame for cartesian jog motions.
 

--- a/source/examples/functions/MceManualMotion/index.md
+++ b/source/examples/functions/MceManualMotion/index.md
@@ -19,7 +19,7 @@ motions are required.
 - Jog TCP (cartesian motion)
 - Inching axis
 - Inching TCP
-- Jog to point (axis or linear)
+- Jog to point (point-to-point or linear)
 - Handles the switching of `MLX.JoggingMode`.
 - Activates the selected Tool and User Frame for cartesian jog motions.
 

--- a/source/examples/functions/MceManualMotion/index.md
+++ b/source/examples/functions/MceManualMotion/index.md
@@ -19,7 +19,7 @@ motions are required.
 - Jog TCP (cartesian motion)
 - Inching axis
 - Inching TCP
-- Jog to point
+- Jog to point (axis or linear)
 - Handles the switching of `MLX.JoggingMode`.
 - Activates the selected Tool and User Frame for cartesian jog motions.
 
@@ -73,6 +73,9 @@ GVL.stManualMotion.aJogRobotAxisNeg := ...;
 GVL.stManualMotion.aJogRobotAxisPos := ...;
 GVL.stManualMotion.nJogType := ...;
 GVL.stManualMotion.nCoordFrame := ...;
+GVL.stManualMotion.bMoveTo := ...;
+GVL.stManualMotion.aTargetPosition := ...;
+GVL.stManualMotion.aTargetType := ...;
 ```
 
 Call the instance:
@@ -93,6 +96,7 @@ to your HMI and/or other programs:
 ... := GVL.stManualMotion.bIdle;
 ... := GVL.stManualMotion.bBusy;
 ... := GVL.stManualMotion.bDone;
+... := GVL.stManualMotion.bError;
 ... := GVL.stManualMotion.aJogRobotAxisNegIndicator;
 ... := GVL.stManualMotion.aJogRobotAxisPosIndicator;
 ```

--- a/source/examples/functions/MceManualMotion/index.md
+++ b/source/examples/functions/MceManualMotion/index.md
@@ -100,3 +100,31 @@ to your HMI and/or other programs:
 ... := GVL.stManualMotion.aJogRobotAxisNegIndicator;
 ... := GVL.stManualMotion.aJogRobotAxisPosIndicator;
 ```
+
+Jogging to a target position does not insure that the TCP speed is limited to
+250 mm/s.
+This is because standard motion commands `MLxRobotMoveAxisAbsolute` and
+`MLxRobotMoveLinearAbsolute` are used.
+
+For an experience similar to the teach pendant when moving the robot to a target
+position, speed parameters are set to the following values.
+These values are hardcoded in the function block.
+
+| `nJogType` value | Speed |
+| ---------------- | ----- |
+| 0                | 3%    |
+| 1                | 10%   |
+
+{{< note warning >}}
+Speed parameter does not limit the TCP speed to *250 mm/s*.
+For safety reasons, make sure to use TCP speed limit function when safety fences
+are opened.
+{{< /note >}}
+
+Acceleration and deceleration default values has been selected to mimic the
+robot behavior when using the teach pendant.
+
+| Parameter | Value |
+| --------- | ----- |
+| `nAcc`    | 40%   |
+| `nDec`    | 80%   |

--- a/source/examples/functions/MceManualMotion/index.md
+++ b/source/examples/functions/MceManualMotion/index.md
@@ -107,13 +107,16 @@ This is because standard motion commands `MLxRobotMoveAxisAbsolute` and
 `MLxRobotMoveLinearAbsolute` are used.
 
 For an experience similar to the teach pendant when moving the robot to a target
-position, speed parameters are set to the following values.
-These values are hardcoded in the function block.
+position, a speed factor is applied to the `nSpeed` input.
+These factors are hardcoded in the function block.
 
-| `nJogType` value | Speed |
-| ---------------- | ----- |
-| 0                | 3%    |
-| 1                | 10%   |
+For example, for a linear motion (`nJogType = 1`) and `nSpeed = 20`, the speed
+passed to the motion command is *2%* (*10%* of *20%*).
+
+| `nJogType` value | Speed factor |
+| ---------------- | ------------ |
+| 0                | 3%           |
+| 1                | 10%          |
 
 {{< note warning >}}
 Speed parameter does not limit the TCP speed to *250 mm/s*.

--- a/source/examples/functions/MceManualMotion/source.iecst
+++ b/source/examples/functions/MceManualMotion/source.iecst
@@ -9,6 +9,9 @@ fbJogAxis.Enable := FALSE;
 fbJogTcp.Enable := FALSE;
 fbMoveAxisRel.Enable := FALSE;
 fbMoveLinRel.Enable := FALSE;
+fbMoveAxisAbsolute.Enable := FALSE;
+fbMoveLinearAbsolute.Enable := FALSE;
+fbStop.Enable := FALSE;
 fbIdleTime.IN := FALSE;
 fbCoastTime.IN := FALSE;
 
@@ -122,7 +125,7 @@ CASE io.nSmManualMotion OF
     nJogTypeSelected := io.nJogType;
     nCoordFrameSelected := io.nCoordFrame;
 
-    IF bOsrRunJog THEN
+    IF bOsrRunJog OR io.bMoveTo THEN
       io.nSmManualMotion := 11;
     END_IF;
 
@@ -161,6 +164,12 @@ CASE io.nSmManualMotion OF
           END_IF;
         END_IF;
       END_IF;
+    ELSIF io.bMoveTo THEN
+      IF bTcpSettingsNeedUpdate THEN
+        io.nSmManualMotion := 15;
+      ELSE
+        io.nSmManualMotion := 40;
+      END_IF;
     ELSE
       io.nSmManualMotion := 10;
     END_IF;
@@ -176,6 +185,8 @@ CASE io.nSmManualMotion OF
     IF bUpdateSettingsDone THEN
       IF (io.bInchingMode) THEN
         io.nSmManualMotion := 35;
+      ELSIF io.bMoveTo THEN
+        io.nSmManualMotion := 40;
       ELSE
         io.nSmManualMotion := 30;
       END_IF;
@@ -367,10 +378,119 @@ CASE io.nSmManualMotion OF
     END_IF;
 
   // -------------------------------------
+  // jog to point, copy target data and select motion type
+  // -------------------------------------
+  40:
+    IF io.bTargetType THEN
+      MEMUtils.MemCpy(pbyDest := ADR(stTargetPoint.TCPPosition.TCPPosition),
+        pbySrc :=  ADR(io.aTargetPosition),
+        dwSize :=  SIZEOF(io.aTargetPosition));
+    ELSE
+      MEMUtils.MemCpy(pbyDest := ADR(stTargetPoint.AxisPosition),
+        pbySrc :=  ADR(io.aTargetPosition),
+        dwSize :=  SIZEOF(io.aTargetPosition));
+    END_IF;
+
+    IF io.bMoveType THEN
+      io.nSmManualMotion := 42;
+    ELSE
+      io.nSmManualMotion := 41;
+    END_IF;
+
+    IF NOT io.bSystemReady THEN
+      io.nSmManualMotion := 0;
+    END_IF;
+
+  // -------------------------------------
+  // jog to point, move axis
+  // -------------------------------------
+  41:
+    MLX.JoggingMode := FALSE;
+    fbMoveAxisAbsolute.Enable := TRUE;
+
+    IF fbMoveAxisAbsolute.Sts_EN AND fbMoveAxisAbsolute.Sts_DN THEN
+      IF NOT io.bSystemReady THEN
+        io.nSmManualMotion := 0;
+      ELSIF fbMoveAxisAbsolute.Sts_ER OR bRobotNumberChanged THEN
+        io.nErrorCode := 1000 + io.nSmManualMotion;
+        io.nSmManualMotion := 99;
+      ELSIF NOT io.bMoveTo THEN
+        io.nSmManualMotion := 45;
+      ELSIF fbMoveAxisAbsolute.Sts_PC THEN
+        io.nSmManualMotion := 50;
+      END_IF;
+    END_IF;
+
+    IF bMlxNumberChanged THEN
+      io.nErrorCode := 1000 + io.nSmManualMotion;
+      io.nSmManualMotion := 99;
+    END_IF;
+
+  // -------------------------------------
+  // jog to point, move linear
+  // -------------------------------------
+  42:
+    MLX.JoggingMode := FALSE;
+    fbMoveLinearAbsolute.Enable := TRUE;
+
+    IF fbMoveLinearAbsolute.Sts_EN AND fbMoveLinearAbsolute.Sts_DN THEN
+      IF NOT io.bSystemReady THEN
+        io.nSmManualMotion := 0;
+      ELSIF fbMoveLinearAbsolute.Sts_ER OR bRobotNumberChanged THEN
+        io.nErrorCode := 1000 + io.nSmManualMotion;
+        io.nSmManualMotion := 99;
+      ELSIF NOT io.bMoveTo THEN
+        io.nSmManualMotion := 45;
+      ELSIF fbMoveLinearAbsolute.Sts_PC THEN
+        io.nSmManualMotion := 50;
+      END_IF;
+    END_IF;
+
+    IF bMlxNumberChanged THEN
+      io.nErrorCode := 1000 + io.nSmManualMotion;
+      io.nSmManualMotion := 99;
+    END_IF;
+
+  // -------------------------------------
+  // jog to point interrupted, stop motion
+  // -------------------------------------
+  45:
+    fbStop.Enable := TRUE;
+
+    IF fbStop.Sts_EN AND fbStop.Sts_DN THEN
+      IF NOT io.bSystemReady THEN
+        io.nSmManualMotion := 0;
+      ELSIF fbMoveLinearAbsolute.Sts_ER OR bRobotNumberChanged THEN
+        io.nErrorCode := 1000 + io.nSmManualMotion;
+        io.nSmManualMotion := 99;
+      ELSE
+        io.nSmManualMotion := 46;
+      END_IF;
+    END_IF;
+
+    IF bMlxNumberChanged THEN
+      io.nErrorCode := 1000 + io.nSmManualMotion;
+      io.nSmManualMotion := 99;
+    END_IF;
+    
+  // -------------------------------------
+  // jog to point, coasting
+  // -------------------------------------
+  46:
+    fbCoastTime.IN := TRUE;
+    IF fbCoastTime.Q THEN
+      io.nSmManualMotion := 50;
+    END_IF;
+
+    IF NOT io.bSystemReady THEN
+      io.nSmManualMotion := 0;
+    END_IF;
+
+  // -------------------------------------
   // done
   // -------------------------------------
   50:
-    IF NOT bJogPressed THEN
+    IF NOT bJogPressed AND NOT io.bMoveTo THEN
       IF io.bSystemReady AND bOperatingModeManual THEN
         io.nSmManualMotion := 10;
       ELSE
@@ -411,7 +531,7 @@ io.bIdle := (io.nSmManualMotion = 0) OR (io.nSmManualMotion = 10);
 bUpdateSettings := (io.nSmManualMotion = 15);
 io.bDone := (io.nSmManualMotion = 50);
 io.bBusy := (io.nSmManualMotion > 10) AND (io.nSmManualMotion < 50);
-io.bCoasting := (io.nSmManualMotion = 22) OR (io.nSmManualMotion = 32) ;
+io.bCoasting := (io.nSmManualMotion = 22) OR (io.nSmManualMotion = 32) OR (io.nSmManualMotion = 46);
 
 FOR i := 0 TO 5 DO
   IF io.bBusy THEN
@@ -561,6 +681,7 @@ fbIdleTime(PT:=io.tIdleTime);
 fbCoastTime(PT:=io.tCoastTime);
 fbSelectTool( MLX := MLX );
 fbSetUserFrame( MLX := MLX );
+fbStop( MLX := MLX );
 
 fbJogAxis(
   RobotNumber := nRobotNumberSelected,
@@ -582,7 +703,7 @@ fbMoveAxisRel(
   Speed := INCHING_SPEED,
   Acceleration := INCHING_ACC_DEC,
   Deceleration := INCHING_ACC_DEC,
-  MLX := MLX );
+  MLX := MLX);
 
 fbMoveLinRel(
   RobotNumber := nRobotNumberSelected,
@@ -594,4 +715,29 @@ fbMoveLinRel(
   Acceleration := INCHING_ACC_DEC,
   Deceleration := INCHING_ACC_DEC,
   CoordFrame := nCoordFrameSelected,
+  MLX := MLX);
+
+fbMoveAxisAbsolute(
+  RobotNumber := nRobotNumberSelected,
+  TargetPosition := stTargetPoint,
+  TargetType := io.bTargetType,
+  BlendFactor := JOG_TO_BF,
+  BlendType := 0,
+  Speed := io.fSpeed * 0.25,
+  Acceleration := io.nAcc,
+  Deceleration := io.nDec,
+  MLX := MLX
+);
+
+fbMoveLinearAbsolute(
+  RobotNumber := nRobotNumberSelected,
+  TargetPosition := stTargetPoint,
+  TargetType := io.bTargetType,
+  BlendFactor := JOG_TO_BF,
+  BlendType := 0,
+  Speed := io.fSpeed * 0.25,
+  UseRotationalSpeed := io.bUseRotationalSpeed,
+  SpeedUnits := 0,
+  Acceleration := io.nAcc,
+  Deceleration := io.nDec,
   MLX := MLX);

--- a/source/examples/functions/MceManualMotion/source.iecst
+++ b/source/examples/functions/MceManualMotion/source.iecst
@@ -723,7 +723,7 @@ fbMoveAxisAbsolute(
   TargetType := io.bTargetType,
   BlendFactor := JOG_TO_BF,
   BlendType := 0,
-  Speed := io.fSpeed * 0.25,
+  Speed := io.fSpeed * 0.03,
   Acceleration := io.nAcc,
   Deceleration := io.nDec,
   MLX := MLX
@@ -735,7 +735,7 @@ fbMoveLinearAbsolute(
   TargetType := io.bTargetType,
   BlendFactor := JOG_TO_BF,
   BlendType := 0,
-  Speed := io.fSpeed * 0.25,
+  Speed := io.fSpeed * 0.1,
   UseRotationalSpeed := io.bUseRotationalSpeed,
   SpeedUnits := 0,
   Acceleration := io.nAcc,

--- a/source/examples/functions/MceManualMotion/source.iecst
+++ b/source/examples/functions/MceManualMotion/source.iecst
@@ -391,6 +391,15 @@ CASE io.nSmManualMotion OF
         dwSize :=  SIZEOF(io.aTargetPosition));
     END_IF;
 
+    CASE nCoordFrameSelected OF
+      // World frame
+      0:
+        stTargetPoint.UserFrameNumber := -1;
+      // Tool or User frame
+      1..2:
+        stTargetPoint.UserFrameNumber := io.nUserFrame;
+    END_CASE;
+
     IF (nJogTypeSelected = JOGTYPE_TCP) THEN
       io.nSmManualMotion := 42;
     ELSE

--- a/source/examples/functions/MceManualMotion/source.iecst
+++ b/source/examples/functions/MceManualMotion/source.iecst
@@ -126,7 +126,7 @@ CASE io.nSmManualMotion OF
       io.nSmManualMotion := 11;
     END_IF;
 
-    IF NOT bOperatingModeManual THEN
+    IF NOT bOperatingModeManual OR NOT io.bSystemReady THEN
       io.nSmManualMotion := 0;
     END_IF;
 
@@ -165,6 +165,10 @@ CASE io.nSmManualMotion OF
       io.nSmManualMotion := 10;
     END_IF;
 
+    IF NOT io.bSystemReady THEN
+      io.nSmManualMotion := 0;
+    END_IF;
+
   // -------------------------------------
   // update TCP settings
   // -------------------------------------
@@ -182,6 +186,10 @@ CASE io.nSmManualMotion OF
       io.nSmManualMotion := 99;
     END_IF;
 
+    IF NOT io.bSystemReady THEN
+      io.nSmManualMotion := 0;
+    END_IF;
+
   // -------------------------------------
   // jog axis with MLxRobotJogAxes
   // -------------------------------------
@@ -192,7 +200,9 @@ CASE io.nSmManualMotion OF
     fbJogAxis.Enable := TRUE;
 
     IF fbJogAxis.Sts_EN AND fbJogAxis.Sts_DN THEN
-      IF fbJogAxis.Sts_ER THEN
+      IF NOT io.bSystemReady THEN
+        io.nSmManualMotion := 0;
+      ELSIF fbJogAxis.Sts_ER OR bRobotNumberChanged THEN
         io.nErrorCode := 1000 + io.nSmManualMotion;
         io.nSmManualMotion := 99;
       ELSE
@@ -200,7 +210,7 @@ CASE io.nSmManualMotion OF
       END_IF;
     END_IF;
 
-    IF bRobotNumberChanged OR bMlxNumberChanged THEN
+    IF bMlxNumberChanged THEN
       io.nErrorCode := 1000 + io.nSmManualMotion;
       io.nSmManualMotion := 99;
     END_IF;
@@ -222,6 +232,10 @@ CASE io.nSmManualMotion OF
       END_IF;
     END_IF;
 
+    IF NOT io.bSystemReady THEN
+      io.nSmManualMotion := 0;
+    END_IF;
+
   // -------------------------------------
   // jog axis - coasting
   // -------------------------------------
@@ -229,6 +243,10 @@ CASE io.nSmManualMotion OF
     fbCoastTime.IN := TRUE;
     IF fbCoastTime.Q THEN
       io.nSmManualMotion := 50;
+    END_IF;
+
+    IF NOT io.bSystemReady THEN
+      io.nSmManualMotion := 0;
     END_IF;
 
   // -------------------------------------
@@ -244,17 +262,17 @@ CASE io.nSmManualMotion OF
     fbMoveAxisRel.Enable := TRUE;
 
     IF fbMoveAxisRel.Sts_EN AND fbMoveAxisRel.Sts_DN THEN
-      IF fbMoveAxisRel.Sts_ER THEN
+      IF NOT io.bSystemReady THEN
+        io.nSmManualMotion := 0;
+      ELSIF fbMoveAxisRel.Sts_ER OR bRobotNumberChanged THEN
         io.nErrorCode := 1000 + io.nSmManualMotion;
         io.nSmManualMotion := 99;
-      END_IF;
-
-      IF fbMoveAxisRel.Sts_PC THEN
+      ELSIF fbMoveAxisRel.Sts_PC THEN
         io.nSmManualMotion := 50;
       END_IF;
     END_IF;
 
-    IF bRobotNumberChanged OR bMlxNumberChanged THEN
+    IF bMlxNumberChanged THEN
       io.nErrorCode := 1000 + io.nSmManualMotion;
       io.nSmManualMotion := 99;
     END_IF;
@@ -269,7 +287,9 @@ CASE io.nSmManualMotion OF
     fbJogTcp.Enable := TRUE;
 
     IF fbJogTcp.Sts_EN AND fbJogTcp.Sts_DN THEN
-      IF fbJogTcp.Sts_ER THEN
+      IF NOT io.bSystemReady THEN
+        io.nSmManualMotion := 0;
+      ELSIF fbJogTcp.Sts_ER OR bRobotNumberChanged THEN
         io.nErrorCode := 1000 + io.nSmManualMotion;
         io.nSmManualMotion := 99;
       ELSE
@@ -277,7 +297,7 @@ CASE io.nSmManualMotion OF
       END_IF;
     END_IF;
 
-    IF bRobotNumberChanged OR bMlxNumberChanged THEN
+    IF bMlxNumberChanged THEN
       io.nErrorCode := 1000 + io.nSmManualMotion;
       io.nSmManualMotion := 99;
     END_IF;
@@ -301,6 +321,10 @@ CASE io.nSmManualMotion OF
       END_IF;
     END_IF;
 
+    IF NOT io.bSystemReady THEN
+      io.nSmManualMotion := 0;
+    END_IF;
+
   // -------------------------------------
   // jog TCP - coasting
   // -------------------------------------
@@ -308,6 +332,10 @@ CASE io.nSmManualMotion OF
     fbCoastTime.IN := TRUE;
     IF fbCoastTime.Q THEN
       io.nSmManualMotion := 50;
+    END_IF;
+
+    IF NOT io.bSystemReady THEN
+      io.nSmManualMotion := 0;
     END_IF;
 
   // -------------------------------------
@@ -323,17 +351,17 @@ CASE io.nSmManualMotion OF
     fbMoveLinRel.Enable := TRUE;
 
     IF fbMoveLinRel.Sts_EN AND fbMoveLinRel.Sts_DN THEN
-      IF fbMoveLinRel.Sts_ER THEN
+      IF NOT io.bSystemReady THEN
+        io.nSmManualMotion := 0;
+      ELSIF fbMoveLinRel.Sts_ER OR bRobotNumberChanged THEN
         io.nErrorCode := 1000 + io.nSmManualMotion;
         io.nSmManualMotion := 99;
-      END_IF;
-
-      IF fbMoveLinRel.Sts_PC THEN
+      ELSIF fbMoveLinRel.Sts_PC THEN
         io.nSmManualMotion := 50;
       END_IF;
     END_IF;
 
-    IF bRobotNumberChanged OR bMlxNumberChanged THEN
+    IF bMlxNumberChanged THEN
       io.nErrorCode := 1000 + io.nSmManualMotion;
       io.nSmManualMotion := 99;
     END_IF;
@@ -348,6 +376,10 @@ CASE io.nSmManualMotion OF
       ELSE
         io.nSmManualMotion := 0;
       END_IF;
+    END_IF;
+
+    IF NOT io.bSystemReady THEN
+      io.nSmManualMotion := 0;
     END_IF;
 
   // -------------------------------------
@@ -367,7 +399,7 @@ END_CASE;
 // -----------------------------------------------------------------------------
 // reset
 // -----------------------------------------------------------------------------
-IF NOT io.bsystemReady THEN
+IF NOT MLX.Signals.MLXGatewayConnected THEN
   io.nSmManualMotion := 0;
 END_IF;
 
@@ -422,7 +454,9 @@ CASE io.nSmSettings OF
     fbSelectTool.ToolNumber := io.nTool;
     fbSelectTool.Enable := TRUE;
     IF fbSelectTool.Sts_EN AND fbSelectTool.Sts_DN THEN
-      IF fbSelectTool.Sts_ER THEN
+      IF NOT io.bSystemReady THEN
+        io.nSmSettings := 0;
+      ELSIF fbSelectTool.Sts_ER THEN
         io.nErrorCode := 2000 + io.nSmSettings;
         io.nSmSettings := 99;
       ELSE
@@ -449,7 +483,9 @@ CASE io.nSmSettings OF
     fbSetUserFrame.Enable := TRUE;
 
     IF fbSetUserFrame.Sts_EN AND fbSetUserFrame.Sts_DN THEN
-      IF fbSetUserFrame.Sts_ER THEN
+      IF NOT io.bSystemReady THEN
+        io.nSmSettings := 0;
+      ELSIF fbSetUserFrame.Sts_ER THEN
         io.nErrorCode := 2000 + io.nSmSettings;
         io.nSmSettings := 99;
       ELSE
@@ -472,12 +508,12 @@ CASE io.nSmSettings OF
     fbMoveAxisRel.Enable := TRUE;
 
     IF fbMoveAxisRel.Sts_EN AND fbMoveAxisRel.Sts_DN THEN
-      IF fbMoveAxisRel.Sts_ER THEN
+      IF NOT io.bSystemReady THEN
+        io.nSmSettings := 0;
+      ELSIF fbMoveAxisRel.Sts_ER THEN
         io.nErrorCode := 2000 + io.nSmSettings;
         io.nSmSettings := 99;
-      END_IF;
-
-      IF fbMoveAxisRel.Sts_PC THEN
+      ELSIF fbMoveAxisRel.Sts_PC THEN
         nUserFrameSelected := io.nUserFrame;
         io.nSmSettings := 50;
       END_IF;
@@ -488,7 +524,7 @@ CASE io.nSmSettings OF
   // -------------------------------------
   50:
     bTcpSettingsNeedUpdate := FALSE;
-    IF NOT bUpdateSettings THEN
+    IF NOT bUpdateSettings OR NOT io.bSystemReady THEN
       io.nSmSettings := 0;
     END_IF;
 
@@ -507,7 +543,7 @@ END_CASE;
 // -----------------------------------------------------------------------------
 // reset
 // -----------------------------------------------------------------------------
-IF NOT io.bsystemReady THEN
+IF NOT MLX.Signals.MLXGatewayConnected THEN
   io.nSmSettings := 0;
 END_IF;
 

--- a/source/examples/functions/MceManualMotion/source.iecst
+++ b/source/examples/functions/MceManualMotion/source.iecst
@@ -391,15 +391,6 @@ CASE io.nSmManualMotion OF
         dwSize :=  SIZEOF(io.aTargetPosition));
     END_IF;
 
-    CASE nCoordFrameSelected OF
-      // World frame
-      0:
-        stTargetPoint.UserFrameNumber := -1;
-      // Tool or User frame
-      1..2:
-        stTargetPoint.UserFrameNumber := io.nUserFrame;
-    END_CASE;
-
     IF (nJogTypeSelected = JOGTYPE_TCP) THEN
       io.nSmManualMotion := 42;
     ELSE

--- a/source/examples/functions/MceManualMotion/source.iecst
+++ b/source/examples/functions/MceManualMotion/source.iecst
@@ -391,7 +391,7 @@ CASE io.nSmManualMotion OF
         dwSize :=  SIZEOF(io.aTargetPosition));
     END_IF;
 
-    IF io.bMoveType THEN
+    IF (nJogTypeSelected = JOGTYPE_TCP) THEN
       io.nSmManualMotion := 42;
     ELSE
       io.nSmManualMotion := 41;

--- a/source/examples/functions/MceManualMotion/source.iecst
+++ b/source/examples/functions/MceManualMotion/source.iecst
@@ -537,14 +537,17 @@ FOR i := 0 TO 5 DO
   IF io.bBusy THEN
     io.aJogRobotAxisNegIndicator[i] := io.aJogRobotAxisNeg[i];
     io.aJogRobotAxisPosIndicator[i] := io.aJogRobotAxisPos[i];
-  END_IF;
-
-  IF NOT io.bBusy AND NOT io.bCoasting THEN
+  ELSE
     io.aJogRobotAxisNegIndicator[i] := FALSE;
     io.aJogRobotAxisPosIndicator[i] := FALSE;
   END_IF;
 END_FOR;
 
+IF io.bBusy THEN
+  io.bMoveToIndicator := io.bMoveTo;
+ELSE
+  io.bMoveToIndicator := FALSE;
+END_IF;
 
 // -----------------------------------------------------------------------------
 // state machine 2: settings

--- a/source/examples/functions/MceManualMotion/source.iecst
+++ b/source/examples/functions/MceManualMotion/source.iecst
@@ -378,7 +378,7 @@ CASE io.nSmManualMotion OF
     END_IF;
 
   // -------------------------------------
-  // jog to point, copy target data and select motion type
+  // jog to point - copy target data
   // -------------------------------------
   40:
     IF io.bTargetType THEN
@@ -402,7 +402,7 @@ CASE io.nSmManualMotion OF
     END_IF;
 
   // -------------------------------------
-  // jog to point, move axis
+  // jog to point - move axis
   // -------------------------------------
   41:
     MLX.JoggingMode := FALSE;
@@ -427,7 +427,7 @@ CASE io.nSmManualMotion OF
     END_IF;
 
   // -------------------------------------
-  // jog to point, move linear
+  // jog to point - move linear
   // -------------------------------------
   42:
     MLX.JoggingMode := FALSE;
@@ -452,7 +452,7 @@ CASE io.nSmManualMotion OF
     END_IF;
 
   // -------------------------------------
-  // jog to point interrupted, stop motion
+  // jog to point - stop motion
   // -------------------------------------
   45:
     fbStop.Enable := TRUE;
@@ -474,7 +474,7 @@ CASE io.nSmManualMotion OF
     END_IF;
     
   // -------------------------------------
-  // jog to point, coasting
+  // jog to point - coasting
   // -------------------------------------
   46:
     fbCoastTime.IN := TRUE;

--- a/source/examples/types/MceManualMotionIO/definition.yaml
+++ b/source/examples/types/MceManualMotionIO/definition.yaml
@@ -264,13 +264,16 @@ var:
 
       Coord frame for the cartesian jog motion.
 
+      When jogging to a target position, select either the `world` frame
+      or the `user` frame.
+
     type: USINT
     default_value: "0"
     comment: |
       input: coord frame for cartesian jog [0=world, 1=tool, 2=user]
     legend:
       0: World frame
-      1: Tool frame
+      1: Tool frame (not available for jog to position)
       2: User frame
 
   - name: nUserFrame

--- a/source/examples/types/MceManualMotionIO/definition.yaml
+++ b/source/examples/types/MceManualMotionIO/definition.yaml
@@ -208,7 +208,7 @@ var:
 
     type: SINT
     comment: "input: acceleration [20 to 100%]"
-    default_value: "100"
+    default_value: "40"
 
   - name: nDec
     description: |
@@ -218,7 +218,7 @@ var:
 
     type: SINT
     comment: "input: deceleration [20 to 100%]"
-    default_value: "100"
+    default_value: "80"
 
   - name: aJogRobotAxisNegIndicator
     description: |

--- a/source/examples/types/MceManualMotionIO/definition.yaml
+++ b/source/examples/types/MceManualMotionIO/definition.yaml
@@ -127,7 +127,15 @@ var:
     description: |
       *Used as input*
 
-      Jog to [`aTargetPosition`](#atargetposition).
+      Jog to [`aTargetPosition`](#atargetposition) in the selected [`nUserFrame`](#nuserframe).
+
+      This function can be used to manually move the robot to a specific
+      position (e.g. the home position).
+
+      If `McePosTable` is used for automatic motion, `bMoveTo` can also be used
+      to jog to a position registered in the *PosTable*.
+      It is convenient for testing a robot position at slow speed with the
+      possibility to stop the motion if a collision is going to occur.
 
     type: BOOL
     comment: "input: jog to target position"
@@ -137,7 +145,7 @@ var:
     description: |
       *Used as input*
 
-      Target position to jog to.
+      Target position for the "jog-to-point" function (`bMoveTo`).
 
       The position type depends on [`aTargetType`](#atargettype) value.
 
@@ -264,7 +272,8 @@ var:
 
       Coord frame for the cartesian jog motion.
 
-      Not considered when jogging to a target position.
+      This only applies to regular jog functions (e.g. `aJogRobotAxisNeg`),
+      not to jogging to a target position (`bMoveTo`).
 
     type: USINT
     default_value: "0"
@@ -279,7 +288,8 @@ var:
     description: |
       *Used as input*
 
-      Selected user frame for cartesian jog (range: `0-GVL.USERFRAMES_UBOUND`).
+      Selected user frame for cartesian jog (range: `0-GVL.USERFRAMES_UBOUND`)
+      and for jogging to a target position (`bMoveTo`).
 
       This input is monitored for changes.
       A change will activate the selected user frame on the next jog command or

--- a/source/examples/types/MceManualMotionIO/definition.yaml
+++ b/source/examples/types/MceManualMotionIO/definition.yaml
@@ -2,6 +2,11 @@ company: Yaskawa Europe GmbH
 author: deGroot
 comment: IO data for the MceManualMotion function
 changelog:
+  - version: 0.3.0
+    date: 2024-12-24
+    author: Rioual
+    added:
+      - jog to point
   - version: 0.1.0
     date: 2022-04-14
     author: deGroot
@@ -117,6 +122,103 @@ var:
     type: ARRAY [0..5] OF BOOL
     comment: "input: jog manipulator: positive direction"
     default_value: "[0, 0, 0, 0, 0, 0]"
+
+  - name: bMoveTo
+    description: |
+      *Used as input*
+
+      Jog to [`aTargetPosition`](#atargetposition).
+
+    type: BOOL
+    comment: "input: jog to target position"
+    default_value: "0"
+
+  - name: aTargetPosition
+    description: |
+      *Used as input*
+
+      Target position to jog to.
+
+      The position type depends on [`aTargetType`](#atargettype) value.
+
+      ```iecst
+      // aTargetType 0 (axis)
+      [0]     // S
+      [1]     // L
+      [2]     // U
+      [3]     // R
+      [4]     // B
+      [5]     // T
+      ```
+
+      ```iecst
+      // aTargetType 1 (cartesian)
+      [0]     // X
+      [1]     // Y
+      [2]     // Z
+      [3]     // Rx
+      [4]     // Ry
+      [5]     // Rz
+      ```
+
+    type: ARRAY [0..5] OF REAL
+    comment: "input: target position for jog to point"
+    default_value: "[0, 0, 0, 0, 0, 0]"
+
+  - name: bTargetType
+    description: |
+      *Used as input*
+
+      Select the target type of [`aTargetPosition`](#atargetposition).
+
+    type: BOOL
+    comment: "input: 0=Axis position [S,L,U,R,B,T]; 1=Cartesian position [X,Y,Z,Rx,Ry,Rz]"
+    legend:
+      "False": Axis position [S,L,U,R,B,T]
+      "True": Cartesian position [X,Y,Z,Rx,Ry,Rz]
+    default_value: "0"
+
+  - name: bUseRotationalSpeed
+    description: |
+      *Used as input*
+
+      Specifies how the speed setting for the jog to point motion should be
+      interpreted.
+
+      By default, the speed setting for a motion to a TCP target position is
+      interpreted as linear speed. That is fine for most cases.
+      However, if the resulting motion of this entry has a big portion
+      of TCP rotational motion and just little (or no) TCP translational motion,
+      it will result in unexpected fast axis motion.
+
+      In such case, this parameter shall be set `True`.
+
+    type: BOOL
+    comment: "input: 0=as linear speed, 1=as rotational speed"
+    legend:
+      "False" : "as linear speed"
+      "True" : "as rotational speed"
+    default_value: "0"
+
+  - name: nAcc
+    description: |
+      *Used as input*
+
+      Acceleration in % of maximum rated acceleration (range: `20-100%`).
+
+    type: SINT
+    comment: "input: acceleration [20 to 100%]"
+    default_value: "100"
+
+  - name: nDec
+    description: |
+      *Used as input*
+
+      Deceleration in % of maximum rated deceleration (range: `20-100%`).
+
+    type: SINT
+    comment: "input: deceleration [20 to 100%]"
+    default_value: "100"
 
   - name: aJogRobotAxisNegIndicator
     description: |

--- a/source/examples/types/MceManualMotionIO/definition.yaml
+++ b/source/examples/types/MceManualMotionIO/definition.yaml
@@ -252,6 +252,18 @@ var:
       "on": jog active
       "off": jog not active
 
+  - name: bMoveToIndicator
+    description: |
+      *Used as output*
+
+      Connect this signal to the indicator light of the jog to position button.
+    
+    type: BOOL
+    comment: "output: indicators for jog to position button"
+    legend:
+      "on": jog to position active
+      "off": jog to position not active
+
   - name: nJogType
     description: |
       *Used as input*

--- a/source/examples/types/MceManualMotionIO/definition.yaml
+++ b/source/examples/types/MceManualMotionIO/definition.yaml
@@ -2,7 +2,7 @@ company: Yaskawa Europe GmbH
 author: deGroot
 comment: IO data for the MceManualMotion function
 changelog:
-  - version: 0.3.0
+  - version: 0.2.0
     date: 2024-12-24
     author: Rioual
     added:
@@ -187,7 +187,7 @@ var:
     type: BOOL
     comment: "input: 0=Point-to-Point move, 1=linear move"
     legend:
-      "0" : "Point-to-point move *(MOVJ)*"
+      "0" : "Point-to-point motion *(MOVJ)*"
       "1" : "Linear motion *(MOVL)*"
     default_value: "1"
 

--- a/source/examples/types/MceManualMotionIO/definition.yaml
+++ b/source/examples/types/MceManualMotionIO/definition.yaml
@@ -6,7 +6,7 @@ changelog:
     date: 2024-12-24
     author: Rioual
     added:
-      - jog to point
+      - jog to point function
   - version: 0.1.0
     date: 2022-04-14
     author: deGroot
@@ -178,19 +178,6 @@ var:
       "True": Cartesian position [X,Y,Z,Rx,Ry,Rz]
     default_value: "0"
 
-  - name: bMoveType
-    description: |
-      *Used as input*
-
-      Select the motion type for jogging to point.
-
-    type: BOOL
-    comment: "input: 0=Point-to-Point move, 1=linear move"
-    legend:
-      "0" : "Point-to-point motion *(MOVJ)*"
-      "1" : "Linear motion *(MOVL)*"
-    default_value: "1"
-
   - name: bUseRotationalSpeed
     description: |
       *Used as input*
@@ -207,10 +194,10 @@ var:
       In such case, this parameter shall be set `True`.
 
     type: BOOL
-    comment: "input: 0=as linear speed, 1=as rotational speed"
+    comment: "input: 0=as linear speed (mm/s), 1=as rotational speed (deg/sec)"
     legend:
-      "False" : "as linear speed"
-      "True" : "as rotational speed"
+      "False" : "as linear speed (mm/s)"
+      "True" : "as rotational speed(deg/sec)"
     default_value: "0"
 
   - name: nAcc
@@ -338,6 +325,11 @@ var:
       "31": jog TCP - idle time
       "32": jog TCP - coasting
       "35": inch TCP with MLxRobotMoveLinearRelative
+      "40": jog to point - copy target data
+      "41": jog to point - move axis
+      "42": jog to point - move linear
+      "45": jog to point - stop motion
+      "46": jog to point - coasting
       "50": done
       "99": error
 

--- a/source/examples/types/MceManualMotionIO/definition.yaml
+++ b/source/examples/types/MceManualMotionIO/definition.yaml
@@ -178,6 +178,19 @@ var:
       "True": Cartesian position [X,Y,Z,Rx,Ry,Rz]
     default_value: "0"
 
+  - name: bMoveType
+    description: |
+      *Used as input*
+
+      Select the motion type for jogging to point.
+
+    type: BOOL
+    comment: "input: 0=Point-to-Point move, 1=linear move"
+    legend:
+      "0" : "Point-to-point move *(MOVJ)*"
+      "1" : "Linear motion *(MOVL)*"
+    default_value: "1"
+
   - name: bUseRotationalSpeed
     description: |
       *Used as input*

--- a/source/examples/types/MceManualMotionIO/definition.yaml
+++ b/source/examples/types/MceManualMotionIO/definition.yaml
@@ -264,8 +264,7 @@ var:
 
       Coord frame for the cartesian jog motion.
 
-      When jogging to a target position, select either the `world` frame
-      or the `user` frame.
+      Not considered when jogging to a target position.
 
     type: USINT
     default_value: "0"


### PR DESCRIPTION
Fixes #61 

# Code changes

## Update `MceManualMotionIO` data type

Add inputs for jog to point function:
- `bMoveTo` to jog to the target position
- `aTargetPosition` the position to jog to
- `bTargetType` the type of position (axis or cartesian)
- `bUseRotationalSpeed` the type of speed
- `nAcc` for acceleration
- `nDec` for deceleration

Add output for jog to point function:
- `bMoveToIndicator` robot is moving to a target position

## Update `MceManualMotion`

- Add the jog to point function