### PR TITLE
Bug/67 Add state machine monitoring

### DIFF
--- a/source/examples/functions/MceStartStop/definition.yaml
+++ b/source/examples/functions/MceStartStop/definition.yaml
@@ -103,15 +103,12 @@ var:
         comment: bits for one shot signals
 
       - name: stStateMonitoringData
-        type: ARRAY [0..2] OF MceStateMonitoringData
+        type: ARRAY [0..1] OF MceStateMonitoringData
         comment: monitor the elapsed time of a state
-      
-      - name: nStateTime
-        type: ARRAY [0..2] OF DINT
-        comment: elapsed time in current state [ms]
+
   - kind: constant
     var:
       - name: DELAY_TIME
         type: INT
-        default_value: 1000
+        default_value: 500
         comment: delay time before allowing state transition

--- a/source/examples/functions/MceStartStop/definition.yaml
+++ b/source/examples/functions/MceStartStop/definition.yaml
@@ -1,6 +1,15 @@
 author: Rioual
 comment: Start/stop logic + speed override
 changelog:
+  - version: 1.1.0
+    date: 2025-01-07
+    author: Rioual
+    added:
+      - state machine monitoring
+    changed:
+      - requires `MceStartStopIO` data type version `0.3.0`
+    fixed:
+      - servos are no longer aborted when robot controller status takes time to update
   - version: 1.0.0
     date: 2024-12-16
     author: Rioual
@@ -92,3 +101,17 @@ var:
       - name: aOneShots
         type: ARRAY [0..4] OF BOOL
         comment: bits for one shot signals
+
+      - name: stStateMonitoringData
+        type: ARRAY [0..2] OF MceStateMonitoringData
+        comment: monitor the elapsed time of a state
+      
+      - name: nStateTime
+        type: ARRAY [0..2] OF DINT
+        comment: elapsed time in current state [ms]
+  - kind: constant
+    var:
+      - name: DELAY_TIME
+        type: INT
+        default_value: 1000
+        comment: delay time before allowing state transition

--- a/source/examples/functions/MceStartStop/source.iecst
+++ b/source/examples/functions/MceStartStop/source.iecst
@@ -124,7 +124,7 @@ CASE io.nSmStartStop OF
       io.nSmStartStop := 60;
     END_IF;
 
-    IF MLX.Signals.AllDrivesDisabled AND (nStateTime[0] >= DELAY_TIME) THEN
+    IF MLX.Signals.AllDrivesDisabled AND (io.nSmStartStopTime >= DELAY_TIME) THEN
       io.nSmStartStop := 0;
     END_IF;
 
@@ -160,7 +160,7 @@ CASE io.nSmStartStop OF
       io.nSmStartStop := 60;
     END_IF;
 
-    IF MLX.Signals.AllDrivesDisabled AND (nStateTime[0] >= DELAY_TIME) THEN
+    IF MLX.Signals.AllDrivesDisabled AND (io.nSmStartStopTime >= DELAY_TIME) THEN
       io.nSmStartStop := 0;
     END_IF;
 
@@ -314,12 +314,12 @@ END_IF;
 // -----------------------------------------------------------------------------
 // state monitoring
 // -----------------------------------------------------------------------------
-nStateTime[0] := MceStateMonitoring(nState := io.nSmStartStop,
-                                    bFreezeTimer := (io.nSmStartStop < 10),
-                                    stateData := stStateMonitoringData[0]);
-nStateTime[1] := MceStateMonitoring(nState := io.nSmSpeedOverride,
-                                    bFreezeTimer := (io.nSmStartStop = 0),
-                                    stateData := stStateMonitoringData[1]);
+io.nSmStartStopTime := MceStateMonitoring(nState := io.nSmStartStop,
+                                          bFreezeTimer := io.bIdle,
+                                          stateData := stStateMonitoringData[0]);
+io.nSmSpeedOverrideTime := MceStateMonitoring(nState := io.nSmSpeedOverride,
+                                              bFreezeTimer := (io.nSmSpeedOverride = 0),
+                                              stateData := stStateMonitoringData[1]);
 
 // -----------------------------------------------------------------------------
 // FB calls

--- a/source/examples/functions/MceStartStop/source.iecst
+++ b/source/examples/functions/MceStartStop/source.iecst
@@ -124,7 +124,7 @@ CASE io.nSmStartStop OF
       io.nSmStartStop := 60;
     END_IF;
 
-    IF MLX.Signals.AllDrivesDisabled THEN
+    IF MLX.Signals.AllDrivesDisabled AND (nStateTime[0] >= DELAY_TIME) THEN
       io.nSmStartStop := 0;
     END_IF;
 
@@ -160,7 +160,7 @@ CASE io.nSmStartStop OF
       io.nSmStartStop := 60;
     END_IF;
 
-    IF MLX.Signals.AllDrivesDisabled THEN
+    IF MLX.Signals.AllDrivesDisabled AND (nStateTime[0] >= DELAY_TIME) THEN
       io.nSmStartStop := 0;
     END_IF;
 
@@ -311,6 +311,15 @@ IF bOsrServoOn THEN
   fSpeedOverrideStored := -1;
 END_IF;
 
+// -----------------------------------------------------------------------------
+// state monitoring
+// -----------------------------------------------------------------------------
+nStateTime[0] := MceStateMonitoring(nState := io.nSmStartStop,
+                                    bFreezeTimer := (io.nSmStartStop < 10),
+                                    stateData := stStateMonitoringData[0]);
+nStateTime[1] := MceStateMonitoring(nState := io.nSmSpeedOverride,
+                                    bFreezeTimer := (io.nSmStartStop = 0),
+                                    stateData := stStateMonitoringData[1]);
 
 // -----------------------------------------------------------------------------
 // FB calls

--- a/source/examples/types/MceStartStopIO/definition.yaml
+++ b/source/examples/types/MceStartStopIO/definition.yaml
@@ -205,3 +205,25 @@ var:
     type: REAL
     default_value: "100.0"
     comment: "input: for overriding the programmed speed [0 to 150%]"
+
+  - name: nSmStartStopTime
+    description: |
+      *Used as output*
+
+      Elapsed time in current state of the Start/Stop ([`nSmStartStop`](#nsmstartstop)) state machine.
+
+      Value is in `ms`.
+
+    type: DINT
+    comment: "elapsed time in current state of StartStop state machine [ms]"
+
+  - name: nSmSpeedOverrideTime
+    description: |
+      *Used as output*
+
+      Elapsed time in current state of the Speed Override ([`nSmSpeedOverride`](#nsmspeedoverride)) state machine.
+
+      Value is in `ms`.
+
+    type: DINT
+    comment: "elapsed time in current state of SpeedOverride state machine [ms]"


### PR DESCRIPTION
Fixes #67 

On a slow MotoLogix system, the `MLX.Signals.AllDrivesDisabled` signal may be slow to update.
This behavior results in a loop on the FB's state machine, resulting in the servos being disabled right after being enabled.

By adding state monitoring and a delay (1000ms), this undesired behavior is avoided.

# Code changes

## Update `MceStartStop`

- add state monitoring
- add a delay on system ready and held states to avoid loops
