### PR TITLE
Feature/43 Rename manual mode input

### DIFF
--- a/source/examples/functions/MceManualMotion/definition.yaml
+++ b/source/examples/functions/MceManualMotion/definition.yaml
@@ -2,6 +2,12 @@ company: Yaskawa Europe GmbH
 author: deGroot
 comment: Handling the manual motion.
 changelog:
+  - version: 1.0.0
+    date: 2025-01-17
+    author: Rioual
+    changed:
+      - requires `MceManualMotionIO` data type version `0.2.0`
+      - mode selection input `nOperatingMode` renamed `bEnableManualMode`
   - version: 0.2.0
     date: 2024-12-20
     author: Rioual
@@ -52,10 +58,6 @@ var:
       - name: bOsrRunJog
         type: BOOL
         comment: rising edge
-
-      - name: bOperatingModeManual
-        type: BOOL
-        comment: "operating mode: manual"
 
       - name: bTcpSettingsNeedUpdate
         type: BOOL

--- a/source/examples/functions/MceManualMotion/source.iecst
+++ b/source/examples/functions/MceManualMotion/source.iecst
@@ -36,10 +36,8 @@ MEMUtils.MemSet(
 // -----------------------------------------------------------------------------
 // common
 // -----------------------------------------------------------------------------
-bOperatingModeManual := (io.nOperatingMode = GVL.OP_MANUAL);
-
 // set jogging mode as default
-MLX.JoggingMode := bOperatingModeManual;
+MLX.JoggingMode := io.bEnableManualMode;
 
 // jog speed
 io.fSpeed := LIMIT(0.1, io.fSpeed, 100);
@@ -107,7 +105,7 @@ CASE io.nSmManualMotion OF
   // idle, not ready for jog
   // -------------------------------------
   0:
-    IF io.bSystemReady AND bOperatingModeManual THEN
+    IF io.bSystemReady AND io.bEnableManualMode THEN
       io.nErrorCode := 0;
       bTcpSettingsNeedUpdate := TRUE;
       io.nSmManualMotion := 10;
@@ -126,7 +124,7 @@ CASE io.nSmManualMotion OF
       io.nSmManualMotion := 11;
     END_IF;
 
-    IF NOT bOperatingModeManual OR NOT io.bSystemReady THEN
+    IF NOT io.bEnableManualMode OR NOT io.bSystemReady THEN
       io.nSmManualMotion := 0;
     END_IF;
 
@@ -224,7 +222,7 @@ CASE io.nSmManualMotion OF
 
     IF fbIdletime.Q THEN
       IF NOT bRunJog OR
-        NOT bOperatingModeManual OR
+        NOT io.bEnableManualMode OR
         bJogTypeChanged THEN
         io.nSmManualMotion := 22;
       ELSE
@@ -311,7 +309,7 @@ CASE io.nSmManualMotion OF
 
     IF fbIdletime.Q THEN
       IF NOT bRunJog OR
-        NOT bOperatingModeManual OR
+        NOT io.bEnableManualMode OR
         bJogTypeChanged OR
         bCoordFrameChanged OR
         bToolChanged THEN
@@ -371,7 +369,7 @@ CASE io.nSmManualMotion OF
   // -------------------------------------
   50:
     IF NOT bJogPressed THEN
-      IF io.bSystemReady AND bOperatingModeManual THEN
+      IF io.bSystemReady AND io.bEnableManualMode THEN
         io.nSmManualMotion := 10;
       ELSE
         io.nSmManualMotion := 0;
@@ -435,7 +433,7 @@ CASE io.nSmSettings OF
   // -------------------------------------
   0:
     IF bUpdateSettings OR
-       (bTcpSettingsNeedUpdate AND io.bSystemReady AND bOperatingModeManual AND io.bIdle) THEN
+       (bTcpSettingsNeedUpdate AND io.bSystemReady AND io.bEnableManualMode AND io.bIdle) THEN
       io.nErrorCode := 0;
       io.nSmSettings := 10;
     END_IF;

--- a/source/examples/types/MceManualMotionIO/definition.yaml
+++ b/source/examples/types/MceManualMotionIO/definition.yaml
@@ -2,6 +2,13 @@ company: Yaskawa Europe GmbH
 author: deGroot
 comment: IO data for the MceManualMotion function
 changelog:
+  - version: 0.2.0
+    date: 2025-01-07
+    author: Rioual
+    added:
+      - input `bEnableManualMode`
+    removed:
+      - input `nOperatingMode`
   - version: 0.1.0
     date: 2022-04-14
     author: deGroot
@@ -29,7 +36,22 @@ var:
     default_value: "0"
 
   - name: nRobotNumber
-  - name: nOperatingMode
+
+  - name: bEnableManualMode
+    description: |
+      *Used as input*
+
+      Set to `True` to enable the manual mode.
+
+      While the manual mode is enabled, the FB is active and manual motions can
+      be performed.
+
+      Disable this parameter when performing automatic motions (e.g. `McePosTable`).
+
+    type: BOOL
+    comment: "input: enable manual mode. Must be set to True to perform any manual motion"
+    default_value: "0"
+
   - name: bSystemReady
 
   - name: bInchingMode

--- a/source/examples/types/_common.yaml
+++ b/source/examples/types/_common.yaml
@@ -126,16 +126,3 @@ var:
       State machine in *done* state.
     type: BOOL
     comment: "output: state machine: done"
-
-  nOperatingMode:
-    description: |
-      Machine operating mode.
-      This signal is produced by [`MceOperatingMode`](../../functions/mceoperatingmode).
-    type: USINT
-    default_value: "0"
-    comment: "input: machine operating mode [0=none, 1=manual, 2=semi-auto, 3=auto]"
-    legend:
-      "0": none
-      "1": manual mode
-      "2": semi-automatic mode (step by step)
-      "3": automatic mode


### PR DESCRIPTION
Fixes #43 

Replace the integer `nOperatingMode` by a boolean `bEnableManualMode`.

# Code changes

## Update `MceManualMotionIO` data type

- remove `nOperatingMode` input
- add a boolean `bEnableManualMode` input

## Update `MceManualMotion`

- reflect modifications of `MceManualMotionIO`
