### PR TITLE
Fix clearing alarm and warning list for Rockwell

### DIFF
--- a/source/examples/functions/MceAlarms/definition.yaml
+++ b/source/examples/functions/MceAlarms/definition.yaml
@@ -1,6 +1,11 @@
 author: deGroot
 comment: Alarm reading + alarm reset
 changelog:
+  - version: 0.2.1
+    date: 2025-02-24
+    author: Rioual
+    changed:
+      - 'fix for clearing alarm list (only relevant for Rockwell)'
   - version: 0.2.0
     date: 2022-02-23
     author: deGroot

--- a/source/examples/functions/MceWarnings/definition.yaml
+++ b/source/examples/functions/MceWarnings/definition.yaml
@@ -1,6 +1,11 @@
 author: deGroot
 comment: Reading warnings
 changelog:
+  - version: 0.3.1
+    date: 2025-02-24
+    author: Rioual
+    changed:
+      - 'fix for clearing warning list (only relevant for Rockwell)'
   - version: 0.3.0
     date: 2022-03-02
     author: deGroot


### PR DESCRIPTION
Fixes #78 

Only relevant for Rockwell.

# Code change

## Update `MceAlarms`

- use a for loop to clear the alarm list

## Update `MceWarning`

- use a for loop to clear the warning list