### PR TITLE
Bug/75 Fix error when enabling bFlush while the robot is moving

### DIFF
--- a/source/examples/functions/MceStartStop/definition.yaml
+++ b/source/examples/functions/MceStartStop/definition.yaml
@@ -1,6 +1,13 @@
 author: Rioual
 comment: Start/stop logic + speed override
 changelog:
+  - version: 1.1.2
+    date: 2025-06-02
+    author: Rioual
+    changed:
+      - requires `MceStartStopIO` data type version `0.3.0`
+    fixed:
+      - error when enabling `bFlush` while the robot is moving
   - version: 1.1.1
     date: 2025-01-09
     author: Rioual

--- a/source/examples/functions/MceStartStop/source.iecst
+++ b/source/examples/functions/MceStartStop/source.iecst
@@ -186,7 +186,7 @@ CASE io.nSmStartStop OF
   50:
     fbStop.Enable := TRUE;
     IF fbStop.Sts_EN AND fbStop.Sts_DN AND (MLX.SystemState <> 9)
-      AND (MLX.SystemState <> 10) AND (MLX.SystemState <> 11) THEN
+      AND (MLX.SystemState <> 10) AND (MLX.SystemState <> 11) AND (MLX.SystemState <> 4) THEN
       IF fbStop.Sts_ER THEN
         io.nErrorCode := 1000 + io.nSmStartStop;
         io.nSmStartStop := 70;


### PR DESCRIPTION
Fixes #75 

## Code changes

### Update `MceStartStop`

- wait for the robot to stop when running `MLxStop`