### PR TITLE
Bug/80 `McePosTable` cycle counter only works if bLastEntry is set

### DIFF
--- a/source/examples/functions/McePosTable/definition.yaml
+++ b/source/examples/functions/McePosTable/definition.yaml
@@ -1,6 +1,11 @@
 author: Rioual
 comment: Performed a trajectory stored in a PosTable
 changelog:
+  - version: 0.7.1
+    date: 2025-06-03
+    author: Rioual
+    fixed:
+      - nCycleNumber not updated if bLastEntry is not set and the last entry is skipped
   - version: 0.7.0
     date: 2024-10-08
     author: Rioual
@@ -97,6 +102,9 @@ var:
       - name: nToolNr
         type: DINT
       - name: nPosTableSize
+      - name: nLastEntryIndex
+        type: DINT
+        comment: last not skipped entry index of posTable (last move or last not skipped entry)
       - name: aEnable
         type: ARRAY [0..QA_MAX] OF BOOL
         comment: enable mapped move instruction

--- a/source/examples/functions/McePosTable/source.iecst
+++ b/source/examples/functions/McePosTable/source.iecst
@@ -1,6 +1,7 @@
 // -----------------------------------------------------------------------------
 // common
 // -----------------------------------------------------------------------------
+nPosTableSize := UINT_TO_INT(SIZEOF(posTable) / SIZEOF(posTable.stEntry[0]));
 io.nIndex := LIMIT(0, io.nIndex, nPosTableSize - 1);
 io.nLoadIndex := LIMIT(0, io.nLoadIndex, nPosTableSize - 1);
 
@@ -13,8 +14,18 @@ aOneShots[2] := io.bRecalcQA;
 bOsfRun := NOT io.bRun AND aOneShots[3];
 aOneShots[3] := io.bRun;
 
-nPosTableSize := UINT_TO_INT(SIZEOF(posTable) / SIZEOF(posTable.stEntry[0]));
-bLastEntryInProcess := posTable.stEntry[io.nIndex].bLastEntry OR (io.nIndex = (nPosTableSize - 1));
+// Search for the last entry of PosTable (either bLastEntry or last not skipped entry)
+nLastEntryIndex := 0;
+FOR i := 0 TO nPosTableSize - 1 DO
+  IF posTable.stEntry[i].bLastEntry OR NOT posTable.stEntry[i].bSkipEntry THEN
+    nLastEntryIndex := i;
+    IF posTable.stEntry[i].bLastEntry THEN
+      EXIT;
+    END_IF;
+  END_IF;
+END_FOR;
+
+bLastEntryInProcess := posTable.stEntry[io.nIndex].bLastEntry OR (io.nIndex = nLastEntryIndex);
 bOsfLastMoveInProcess := NOT bLastEntryInProcess AND aOneShots[4];
 aOneShots[4] := bLastEntryInProcess;
 


### PR DESCRIPTION
Fixes #80 

## Code changes

### Update `McePosTable`

- Check which entry is the last. It is used to determine if the last entry is being run and if the cycle counter should be increased