### PR TITLE
Bug/90 Fis doing manual linear motion in a tilted user frame

### DIFF
--- a/source/examples/functions/MceManualMotion/definition.yaml
+++ b/source/examples/functions/MceManualMotion/definition.yaml
@@ -3,10 +3,11 @@ author: deGroot
 comment: Handling the manual motion.
 changelog:
   - version: 1.0.1
-    date: 2025-06-03
+    date: 2025-06-06
     author: Rioual
     fixed:
       - state machine stuck when an alarm occurs
+      - doing linear manual motion in a user frame (only relevant for Rockwell)
   - version: 1.0.0
     date: 2025-01-07
     author: Rioual


### PR DESCRIPTION
Fixes #90 

Only relevant for Rockwell

## Code change

### Update `MceManualMotion`

- copy the 6 elements [X,Y,Z,Rx,Ry,Rz] of the user frame data