### PR TITLE
Bug/96 Rename constant in Siemens

### DIFF
--- a/source/examples/functions/McePosTable/definition.yaml
+++ b/source/examples/functions/McePosTable/definition.yaml
@@ -2,11 +2,12 @@ author: Rioual
 comment: Performed a trajectory stored in a PosTable
 changelog:
   - version: 0.7.1
-    date: 2025-06-03
+    date: 2025-06-06
     author: Rioual
     fixed:
       - nCycleNumber not updated if bLastEntry is not set and the last entry is skipped
       - error code number returned by `nErrorCode`
+      - rename `NR_OF_INSTANCES` in `INSTANCES_UBOUND` (only relevant for Siemens)
   - version: 0.7.0
     date: 2024-10-08
     author: Rioual

--- a/source/examples/functions/McePosTableRecalcQA/definition.yaml
+++ b/source/examples/functions/McePosTableRecalcQA/definition.yaml
@@ -1,6 +1,11 @@
 author: Rioual
 comment: Recalculate the Queuing Amount
 changelog:
+  - version: 0.4.1
+    date: 2025-06-06
+    author: Rioual
+    fixed:
+      - rename `NR_OF_INSTANCES` in `INSTANCES_UBOUND` (only relevant for Siemens)
   - version: 0.4.0
     date: 2024-05-15
     author: Rioual

--- a/source/examples/functions/McePosTableUpdateLoadIndex/definition.yaml
+++ b/source/examples/functions/McePosTableUpdateLoadIndex/definition.yaml
@@ -1,6 +1,11 @@
 author: Rioual
 comment: Update the PosTable LoadIndex; for sending next motion
 changelog:
+  - version: 0.4.1
+    date: 2025-06-06
+    author: Rioual
+    added:
+      - rename `NR_OF_INSTANCES` in `INSTANCES_UBOUND` (only relevant for Siemens)
   - version: 0.4.0
     date: 2024-05-15
     author: Rioual


### PR DESCRIPTION
Fixes #96 

Only relevant for Siemens.

## Code change

### Update `McePosTable`

- rename `NR_OF_INSTANCES` in `INSTANCES_UBOUND`

### Update `McePosTableRecalcQA`

- rename `NR_OF_INSTANCES` in `INSTANCES_UBOUND`

### Update `McePosTableUpdateLoadIndex`

- rename `NR_OF_INSTANCES` in `INSTANCES_UBOUND`