### PR TITLE
fix unnecessary error in manual mode (#102)

### DIFF
--- a/source/examples/functions/McePosTable/definition.yaml
+++ b/source/examples/functions/McePosTable/definition.yaml
@@ -1,6 +1,11 @@
 author: Rioual
 comment: Performed a trajectory stored in a PosTable
 changelog:
+  - version: 0.9.1
+    date: 2026-05-20
+    author: deGroot
+    fixed:
+      - error when operating mode manual while PosTable not running
   - version: 0.9.0
     date: 2026-04-01
     author: deGroot

--- a/source/examples/functions/McePosTable/source.iecst
+++ b/source/examples/functions/McePosTable/source.iecst
@@ -653,7 +653,7 @@ io.bDone := (io.nSmPosTable = 50);
 io.bIdle := (io.nSmPosTable < 5);
 io.bBusy := (io.nSmPosTable >= 5 AND io.nSmPosTable < 50);
 io.aMissingConditions := stConditionResult.aMissingConditions;
-bError := MLX.JoggingMode;
+bError := MLX.JoggingMode AND io.bBusy;
 FOR i := 0 TO QA_MAX DO
   bError := bError OR (aMoveCmd[i].bSts_EN AND aMoveCmd[i].bSts_ER)
         OR (fbRobotSelectTool[i].Sts_EN AND fbRobotSelectTool[i].Sts_ER)


### PR DESCRIPTION
This PR fixes the state machine unnecessarily going in error.

See details in the [bug report](https://github.com/YaskawaEurope/mlx-examples/issues/102).

closes #102 